### PR TITLE
Faster performance and etc.

### DIFF
--- a/docs/src/math.md
+++ b/docs/src/math.md
@@ -299,8 +299,8 @@ Therefore, to satisfy partition of unity on closed interval ``[k_{p+1}, k_{l-p}]
 {B}_{(i,0,k)}(t)
 &=
 \begin{cases}
-    &1\quad (k_{i} \le t<k_{i+1}<k_{l})\\
-    &1\quad (k_{i} \le t \le k_{i+1}=k_{l})\\
+    &1\quad (k_{i} \le t<k_{i+1})\\
+    &1\quad (k_{i} < t = k_{i+1}=k_{l})\\
     &0\quad (\text{otherwise})
 \end{cases}
 \end{aligned}

--- a/src/_FastBSplineBasis.jl
+++ b/src/_FastBSplineBasis.jl
@@ -25,7 +25,7 @@ end
 for p in 0:MAX_DEGREE
     @eval function bsplinebasis₊₀(i::Integer, P::FastBSplineSpace{$p}, t::Real)
         ÷(a, b) = ifelse(b == 0.0, 0.0, a / b)
-        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knotvector[i+" * string(j) * "]" for j in 0:p+1], ',')))
+        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knots[i+" * string(j) * "]" for j in 0:p+1], ',')))
         $(Meta.parse(
             join([_s('B', j) for j in 1:p+1], ',') * " = " * join(["Float64(" * _s('k', j) * " ≤ t < " * _s('k', j + 1) * ")" for j in 1:p+1], ','),
         ))
@@ -34,7 +34,7 @@ for p in 0:MAX_DEGREE
     end
     @eval function bsplinebasis₋₀(i::Integer, P::FastBSplineSpace{$p}, t::Real)
         ÷(a, b) = ifelse(b == 0.0, 0.0, a / b)
-        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knotvector[i+" * string(j) * "]" for j in 0:p+1], ',')))
+        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knots[i+" * string(j) * "]" for j in 0:p+1], ',')))
         $(Meta.parse(
             join([_s('B', j) for j in 1:p+1], ',') * " = " * join(["Float64(" * _s('k', j) * " < t ≤ " * _s('k', j + 1) * ")" for j in 1:p+1], ','),
         ))
@@ -43,8 +43,8 @@ for p in 0:MAX_DEGREE
     end
     @eval function bsplinebasis(i::Integer, P::FastBSplineSpace{$p}, t::Real)
         ÷(a, b) = ifelse(b == 0.0, 0.0, a / b)
-        k_end = P.knotvector[end]
-        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knotvector[i+" * string(j) * "]" for j in 0:p+1], ',')))
+        k_end = P.knots[end]
+        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knots[i+" * string(j) * "]" for j in 0:p+1], ',')))
         $(Meta.parse(
             join([_s('B', j) for j in 1:p+1], ',') * " = " * join(["Float64(" * _s('k', j) * " ≤ t < " * _s('k', j + 1) * ")" for j in 1:p+1], ','),
         ))
@@ -61,7 +61,7 @@ bsplinebasis′(i::Integer, P::FastBSplineSpace{0}, t::Real) = 0.0
 for p in 1:MAX_DEGREE
     @eval function bsplinebasis′₊₀(i::Integer, P::FastBSplineSpace{$p}, t::Real)
         ÷(a, b) = ifelse(b == 0.0, 0.0, a / b)
-        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knotvector[i+" * string(j) * "]" for j in 0:p+1], ',')))
+        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knots[i+" * string(j) * "]" for j in 0:p+1], ',')))
         $(Meta.parse(
             join([_s('B', j) for j in 1:p+1], ',') * " = " * join(["Float64(" * _s('k', j) * " ≤ t < " * _s('k', j + 1) * ")" for j in 1:p+1], ','),
         ))
@@ -72,7 +72,7 @@ for p in 1:MAX_DEGREE
     end
     @eval function bsplinebasis′₋₀(i::Integer, P::FastBSplineSpace{$p}, t::Real)
         ÷(a, b) = ifelse(b == 0.0, 0.0, a / b)
-        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knotvector[i+" * string(j) * "]" for j in 0:p+1], ',')))
+        $(Meta.parse(join([_s('k', j) for j in 1:p+2], ',') * " = " * join(["P.knots[i+" * string(j) * "]" for j in 0:p+1], ',')))
         $(Meta.parse(
             join([_s('B', j) for j in 1:p+1], ',') * " = " * join(["Float64(" * _s('k', j) * " < t ≤ " * _s('k', j + 1) * ")" for j in 1:p+1], ','),
         ))
@@ -83,8 +83,8 @@ for p in 1:MAX_DEGREE
     end
     # @eval function bsplinebasis′(i::Integer, P::FastBSplineSpace{$p}, t::Real)
     #     ÷(a,b) = ifelse(b == 0.0, 0.0, a/b)
-    #     k_end = P.knotvector[end]
-    #     $(Meta.parse(join([_s('k',j) for j in 1:p+2],',')*" = "*join(["P.knotvector[i+"*string(j)*"]" for j in 0:p+1],',')))
+    #     k_end = P.knots[end]
+    #     $(Meta.parse(join([_s('k',j) for j in 1:p+2],',')*" = "*join(["P.knots[i+"*string(j)*"]" for j in 0:p+1],',')))
     #     $(Meta.parse(join([_s('B',j) for j in 1:p+1],',')*" = "*join(["Float64("*_s('k',j)*" ≤ t < "*_s('k',j+1)*")" for j in 1:p+1],',')))
     #     $(Meta.parse(_s('B',p+1)*" += Float64(t == "*_s('k',p+2)*" == k_end)"))
     #     $(Meta.parse("begin "*join([_code_K(p,q)*"\n"*_code_B(p,q) for q in 1:p-1],'\n')*" end"))
@@ -158,17 +158,17 @@ Assumption:
 end
 
 @inline function _bsplinebasis(P::FastBSplineSpace{0}, t::Real, i::Integer)
-    return _bsb0(P.knotvector,t,i)
+    return _bsb0(P.knots,t,i)
 end
 
 @inline function _bsplinebasis(P::FastBSplineSpace{1}, t::Real, i::Integer)
-    return _bsb1(P.knotvector,t,i)
+    return _bsb1(P.knots,t,i)
 end
 
 @inline function _bsplinebasis(P::FastBSplineSpace{2}, t::Real, i::Integer)
-    return _bsb2(P.knotvector,t,i)
+    return _bsb2(P.knots,t,i)
 end
 
 @inline function _bsplinebasis(P::FastBSplineSpace{3}, t::Real, i::Integer)
-    return _bsb3(P.knotvector,t,i)
+    return _bsb3(P.knots,t,i)
 end

--- a/src/_FastBSplineManifold.jl
+++ b/src/_FastBSplineManifold.jl
@@ -20,14 +20,14 @@ struct FastBSplineManifold <: AbstractBSplineManifold
 end
 
 struct BSplineCurve{p1} <: AbstractBSplineManifold
-    knotvector1::Vector{Float64}
+    knots1::Knots
     controlpoints::Array{Float64,2}
     function BSplineCurve(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1]).vector
+        p1, k1 = degree(Ps[1]), knots(Ps[1])
         if collect(size(a)[1:end-1]) ≠ dim.(Ps)
             error("dimension does not match")
-        elseif p1 > MAX_DEGREE
-            return BSplineManifold(Ps, a)
+        # elseif p1 > MAX_DEGREE
+        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
             new{p1}(k1, a)
@@ -39,16 +39,16 @@ function BSplineCurve{q1}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::Abstrac
 end
 
 struct BSplineSurface{p1,p2} <: AbstractBSplineManifold
-    knotvector1::Vector{Float64}
-    knotvector2::Vector{Float64}
+    knots1::Knots
+    knots2::Knots
     controlpoints::Array{Float64,3}
     function BSplineSurface(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1]).vector
-        p2, k2 = degree(Ps[2]), knots(Ps[2]).vector
+        p1, k1 = degree(Ps[1]), knots(Ps[1])
+        p2, k2 = degree(Ps[2]), knots(Ps[2])
         if collect(size(a)[1:end-1]) ≠ dim.(Ps)
             error("dimension does not match")
-        elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE
-            return BSplineManifold(Ps, a)
+        # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE
+        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
             new{p1,p2}(k1, k2, a)
@@ -60,18 +60,18 @@ function BSplineSurface{q1,q2}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::Ab
 end
 
 struct BSplineSolid{p1,p2,p3} <: AbstractBSplineManifold
-    knotvector1::Vector{Float64}
-    knotvector2::Vector{Float64}
-    knotvector3::Vector{Float64}
+    knots1::Knots
+    knots2::Knots
+    knots3::Knots
     controlpoints::Array{Float64,4}
     function BSplineSolid(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1]).vector
-        p2, k2 = degree(Ps[2]), knots(Ps[2]).vector
-        p3, k3 = degree(Ps[3]), knots(Ps[3]).vector
+        p1, k1 = degree(Ps[1]), knots(Ps[1])
+        p2, k2 = degree(Ps[2]), knots(Ps[2])
+        p3, k3 = degree(Ps[3]), knots(Ps[3])
         if collect(size(a)[1:end-1]) ≠ dim.(Ps)
             error("dimension does not match")
-        elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE || p3 > MAX_DEGREE
-            return BSplineManifold(Ps, a)
+        # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE || p3 > MAX_DEGREE
+        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
             new{p1,p2,p3}(k1, k2, k3, a)
@@ -91,27 +91,27 @@ for fname in (:BSplineCurve, :BSplineSurface, :BSplineSolid, :FastBSplineManifol
 end
 
 function BSplineManifold(M::BSplineCurve{p1}) where {p1}
-    k1 = Knots(M.knotvector1)
+    k1 = M.knots1
     P1 = BSplineSpace(p1, k1)
     a = M.controlpoints
     return BSplineManifold([P1], a)
 end
 
 function BSplineManifold(M::BSplineSurface{p1,p2}) where {p1} where {p2}
-    k1 = Knots(M.knotvector1)
+    k1 = M.knots1
     P1 = BSplineSpace(p1, k1)
-    k2 = Knots(M.knotvector2)
+    k2 = M.knots2
     P2 = BSplineSpace(p2, k2)
     a = M.controlpoints
     return BSplineManifold([P1, P2], a)
 end
 
 function BSplineManifold(M::BSplineSolid{p1,p2,p3}) where {p1} where {p2} where {p3}
-    k1 = Knots(M.knotvector1)
+    k1 = M.knots1
     P1 = BSplineSpace(p1, k1)
-    k2 = Knots(M.knotvector2)
+    k2 = M.knots2
     P2 = BSplineSpace(p2, k2)
-    k3 = Knots(M.knotvector3)
+    k3 = M.knots3
     P3 = BSplineSpace(p3, k3)
     a = M.controlpoints
     return BSplineManifold([P1, P2, P3], a)
@@ -145,7 +145,7 @@ function (M::BSplineCurve{p1})(t::AbstractVector{<:Real}) where {p1}
     a = controlpoints(M)
     n1 = dim(P1)
     t1, = t
-    v1 = M.knotvector1
+    v1 = M.knots1
     j1 = _knotindex(v1, t1)
     b1 = _bsplinebasis(P1,t1,j1)
     d̂ = size(a)[end]
@@ -168,7 +168,7 @@ function (M::BSplineSurface{p1,p2})(t::AbstractVector{<:Real}) where {p1} where 
     a = controlpoints(M)
     n1, n2 = dim(P1), dim(P2)
     t1, t2 = t
-    v1, v2 = M.knotvector1, M.knotvector2
+    v1, v2 = M.knots1, M.knots2
     j1, j2 = _knotindex(v1, t1), _knotindex(v2, t2)
     b1 = _bsplinebasis(P1,t1,j1)
     b2 = _bsplinebasis(P2,t2,j2)
@@ -201,7 +201,7 @@ function (M::BSplineSolid{p1,p2,p3})(t::AbstractVector{<:Real}) where {p1} where
     a = controlpoints(M)
     n1, n2, n3 = dim(P1), dim(P2), dim(P3)
     t1, t2, t3 = t
-    v1, v2, v3 = M.knotvector1, M.knotvector2, M.knotvector3
+    v1, v2, v3 = M.knots1, M.knots2, M.knots3
     j1, j2, j3 = _knotindex(v1, t1), _knotindex(v2, t2), _knotindex(v3, t3)
     b1 = _bsplinebasis(P1,t1,j1)
     b2 = _bsplinebasis(P2,t2,j2)
@@ -257,15 +257,15 @@ function bsplinespaces(M::FastBSplineManifold)
 end
 
 function bsplinespaces(M::BSplineCurve{p1}) where {p1}
-    return (FastBSplineSpace(p1, Knots(M.knotvector1)), )
+    return (FastBSplineSpace(p1, M.knots1), )
 end
 
 function bsplinespaces(M::BSplineSurface{p1,p2}) where {p1} where {p2}
-    return (FastBSplineSpace(p1, Knots(M.knotvector1)), FastBSplineSpace(p2, Knots(M.knotvector2)))
+    return (FastBSplineSpace(p1, M.knots1), FastBSplineSpace(p2, M.knots2))
 end
 
 function bsplinespaces(M::BSplineSolid{p1,p2,p3}) where {p1} where {p2} where {p3}
-    return (FastBSplineSpace(p1, Knots(M.knotvector1)), FastBSplineSpace(p2, Knots(M.knotvector2)), FastBSplineSpace(p3, Knots(M.knotvector3)))
+    return (FastBSplineSpace(p1, M.knots1), FastBSplineSpace(p2, M.knots2), FastBSplineSpace(p3, M.knots3))
 end
 
 function controlpoints(M::FastBSplineManifold)

--- a/src/_FastBSplineManifold.jl
+++ b/src/_FastBSplineManifold.jl
@@ -20,18 +20,27 @@ struct FastBSplineManifold <: AbstractBSplineManifold
 end
 
 struct BSplineCurve{p1} <: AbstractBSplineManifold
-    knots1::Knots
+    bsplinespace1::FastBSplineSpace{p1}
     controlpoints::Array{Float64,2}
-    function BSplineCurve(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1])
-        if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+    function BSplineCurve(P1::AbstractBSplineSpace, a::AbstractArray{<:Real})
+        p1 = degree(P1)
+        if size(a)[1:end-1] ≠ (dim(P1),)
             error("dimension does not match")
-        # elseif p1 > MAX_DEGREE
-        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
-            new{p1}(k1, a)
+            new{p1}(P1, a)
         end
+    end
+end
+function BSplineCurve(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
+    # p1, k1 = degree(Ps[1]), knots(Ps[1])
+    if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+        error("dimension does not match")
+    # elseif p1 > MAX_DEGREE
+    #     return BSplineManifold(Ps, a)
+    else
+        a = convert(Array{Float64}, a)
+        return BSplineCurve(Ps[1],a)
     end
 end
 function BSplineCurve{q1}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real}) where {q1}
@@ -39,20 +48,29 @@ function BSplineCurve{q1}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::Abstrac
 end
 
 struct BSplineSurface{p1,p2} <: AbstractBSplineManifold
-    knots1::Knots
-    knots2::Knots
+    bsplinespace1::FastBSplineSpace{p1}
+    bsplinespace2::FastBSplineSpace{p2}
     controlpoints::Array{Float64,3}
-    function BSplineSurface(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1])
-        p2, k2 = degree(Ps[2]), knots(Ps[2])
-        if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+    function BSplineSurface(P1::AbstractBSplineSpace, P2::AbstractBSplineSpace, a::AbstractArray{<:Real})
+        p1, p2 = degree(P1), degree(P2)
+        if size(a)[1:end-1] ≠ (dim(P1), dim(P2))
             error("dimension does not match")
-        # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE
-        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
-            new{p1,p2}(k1, k2, a)
+            new{p1,p2}(P1, P2, a)
         end
+    end
+end
+function BSplineSurface(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
+    # p1, k1 = degree(Ps[1]), knots(Ps[1])
+    # p2, k2 = degree(Ps[2]), knots(Ps[2])
+    if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+        error("dimension does not match")
+    # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE
+    #     return BSplineManifold(Ps, a)
+    else
+        a = convert(Array{Float64}, a)
+        return BSplineSurface(Ps[1], Ps[2], a)
     end
 end
 function BSplineSurface{q1,q2}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real}) where {q1} where {q2}
@@ -60,22 +78,31 @@ function BSplineSurface{q1,q2}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::Ab
 end
 
 struct BSplineSolid{p1,p2,p3} <: AbstractBSplineManifold
-    knots1::Knots
-    knots2::Knots
-    knots3::Knots
+    bsplinespace1::FastBSplineSpace{p1}
+    bsplinespace2::FastBSplineSpace{p2}
+    bsplinespace3::FastBSplineSpace{p3}
     controlpoints::Array{Float64,4}
-    function BSplineSolid(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
-        p1, k1 = degree(Ps[1]), knots(Ps[1])
-        p2, k2 = degree(Ps[2]), knots(Ps[2])
-        p3, k3 = degree(Ps[3]), knots(Ps[3])
-        if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+    function BSplineSolid(P1::AbstractBSplineSpace, P2::AbstractBSplineSpace, P3::AbstractBSplineSpace, a::AbstractArray{<:Real})
+        p1, p2, p3 = degree(P1), degree(P2), degree(P3)
+        if size(a)[1:end-1] ≠ (dim(P1), dim(P2), dim(P3))
             error("dimension does not match")
-        # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE || p3 > MAX_DEGREE
-        #     return BSplineManifold(Ps, a)
         else
             a = convert(Array{Float64}, a)
-            new{p1,p2,p3}(k1, k2, k3, a)
+            new{p1,p2,p3}(P1, P2, P3, a)
         end
+    end
+end
+function BSplineSolid(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real})
+    # p1, k1 = degree(Ps[1]), knots(Ps[1])
+    # p2, k2 = degree(Ps[2]), knots(Ps[2])
+    # p3, k3 = degree(Ps[3]), knots(Ps[3])
+    if collect(size(a)[1:end-1]) ≠ dim.(Ps)
+        error("dimension does not match")
+    # elseif p1 > MAX_DEGREE || p2 > MAX_DEGREE || p3 > MAX_DEGREE
+    #     return BSplineManifold(Ps, a)
+    else
+        a = convert(Array{Float64}, a)
+        BSplineSolid(Ps[1],Ps[2],Ps[3],a)
     end
 end
 function BSplineSolid{q1,q2,q3}(Ps::AbstractVector{<:AbstractBSplineSpace}, a::AbstractArray{<:Real}) where {q1} where {q2} where {q3}
@@ -134,7 +161,7 @@ function (M::BSplineCurve{p1})(t::AbstractVector{<:Real}) where {p1}
     a = controlpoints(M)
     n1 = dim(P1)
     t1, = t
-    v1 = M.knots1
+    v1 = P1.knots.vector
     j1 = _knotindex(v1, t1)
     b1 = _bsplinebasis(P1,t1,j1)
     d̂ = size(a)[end]
@@ -157,7 +184,7 @@ function (M::BSplineSurface{p1,p2})(t::AbstractVector{<:Real}) where {p1} where 
     a = controlpoints(M)
     n1, n2 = dim(P1), dim(P2)
     t1, t2 = t
-    v1, v2 = M.knots1, M.knots2
+    v1, v2 = P1.knots.vector, P2.knots.vector
     j1, j2 = _knotindex(v1, t1), _knotindex(v2, t2)
     b1 = _bsplinebasis(P1,t1,j1)
     b2 = _bsplinebasis(P2,t2,j2)
@@ -186,11 +213,11 @@ function (M::BSplineSurface{p1,p2})(t::AbstractVector{<:Real}) where {p1} where 
 end
 
 function (M::BSplineSolid{p1,p2,p3})(t::AbstractVector{<:Real}) where {p1} where {p2} where {p3}
-    P1, P2, P3 = bsplinespaces(M)
+    P1, P2, P3 = M.bsplinespace1, M.bsplinespace2, M.bsplinespace3
     a = controlpoints(M)
     n1, n2, n3 = dim(P1), dim(P2), dim(P3)
     t1, t2, t3 = t
-    v1, v2, v3 = M.knots1, M.knots2, M.knots3
+    v1, v2, v3 = P1.knots.vector, P2.knots.vector, P3.knots.vector
     j1, j2, j3 = _knotindex(v1, t1), _knotindex(v2, t2), _knotindex(v3, t3)
     b1 = _bsplinebasis(P1,t1,j1)
     b2 = _bsplinebasis(P2,t2,j2)
@@ -246,15 +273,15 @@ function bsplinespaces(M::FastBSplineManifold)
 end
 
 function bsplinespaces(M::BSplineCurve{p1}) where {p1}
-    return (FastBSplineSpace(p1, M.knots1), )
+    return (M.bsplinespace1, )
 end
 
 function bsplinespaces(M::BSplineSurface{p1,p2}) where {p1} where {p2}
-    return (FastBSplineSpace(p1, M.knots1), FastBSplineSpace(p2, M.knots2))
+    return (M.bsplinespace1, M.bsplinespace2)
 end
 
 function bsplinespaces(M::BSplineSolid{p1,p2,p3}) where {p1} where {p2} where {p3}
-    return (FastBSplineSpace(p1, M.knots1), FastBSplineSpace(p2, M.knots2), FastBSplineSpace(p3, M.knots3))
+    return (M.bsplinespace1, M.bsplinespace2, M.bsplinespace3)
 end
 
 function controlpoints(M::FastBSplineManifold)

--- a/src/_FastBSplineManifold.jl
+++ b/src/_FastBSplineManifold.jl
@@ -124,19 +124,8 @@ function FastBSplineManifold(M::AbstractBSplineManifold)
     return FastBSplineManifold(BSplineSpace.(M.bsplinespaces), M.controlpoints)
 end
 
-@doc raw"""
-Calculate the mapping of B-spline manifold for given parameter.
-```math
-\bm{p}(t^1,\dots,t^d)
-=\sum_{i^1,\dots,i^d}B_{i^1,\dots,i^d}(t^1,\dots,t^d) \bm{a}_{i^1,\dots,i^d}
-```
-"""
-# function mapping(M::FastBSplineManifold, t::AbstractVector{<:Real})
-#     # TODO: faster
-#     return mapping(BSplineManifold(M), t)
-# end
-
 function (M::FastBSplineManifold)(t::AbstractVector{<:Real})
+    # TODO: faster
     return BSplineManifold(M)(t)
 end
 

--- a/src/_FastBSplineSpace.jl
+++ b/src/_FastBSplineSpace.jl
@@ -4,23 +4,18 @@
 B-spline space for lower polynomial degree
 """
 struct FastBSplineSpace{p} <: AbstractBSplineSpace
-    knotvector::Array{Float64,1}
+    knots::Knots
     function FastBSplineSpace(p::Integer, knots::Knots)
         if p < 0
             error("degree of polynominal must be non-negative")
         elseif p > MAX_DEGREE
             error("FastBSpline supports only degree 0 , ... , $(MAX_DEGREE)")
         end
-        new{p}(knots.vector)
+        new{p}(knots)
     end
-    function FastBSplineSpace{q}(p::Integer, knots::Knots) where {q}
-        if p < 0
-            error("degree of polynominal must be non-negative")
-        elseif p > MAX_DEGREE
-            error("FastBSpline supports only degree 0 , ... , $(MAX_DEGREE)")
-        end
-        new{p}(knots.vector)
-    end
+end
+function FastBSplineSpace{q}(p::Integer, knots::Knots) where {q}
+    FastBSplineSpace(p,knots)
 end
 
 """
@@ -35,5 +30,5 @@ function degree(P::FastBSplineSpace{p}) where {p}
 end
 
 function knots(P::FastBSplineSpace)
-    return Knots(P.knotvector)
+    return P.knots
 end

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -264,6 +264,7 @@ function innerproduct_R(func, P1::AbstractBSplineSpace)
     nip1 = p1 + 1
     nodes1, weights1 = gausslegendre(nip1)
     b = [_f_b_int_R(func, i1, P1, nip1, nodes1, weights1) for i1 in 1:n1]
+    return b
 end
 
 function innerproduct_I(func, P1::AbstractBSplineSpace)
@@ -272,6 +273,7 @@ function innerproduct_I(func, P1::AbstractBSplineSpace)
     nip1 = p1 + 1
     nodes1, weights1 = gausslegendre(nip1)
     b = [_f_b_int_I(func, i1, P1, nip1, nodes1, weights1) for i1 in 1:n1]
+    return b
 end
 
 function innerproduct_R(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace)
@@ -282,6 +284,7 @@ function innerproduct_R(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace
     nodes1, weights1 = gausslegendre(nip1)
     nodes2, weights2 = gausslegendre(nip2)
     b = [_f_b_int_R(func, i1, i2, P1, P2, nip1, nip2, nodes1, nodes2, weights1, weights2) for i1 in 1:n1, i2 in 1:n2]
+    return b
 end
 
 function innerproduct_I(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace)
@@ -292,6 +295,7 @@ function innerproduct_I(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace
     nodes1, weights1 = gausslegendre(nip1)
     nodes2, weights2 = gausslegendre(nip2)
     b = [_f_b_int_I(func, i1, i2, P1, P2, nip1, nip2, nodes1, nodes2, weights1, weights2) for i1 in 1:n1, i2 in 1:n2]
+    return b
 end
 
 function innerproduct_R(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace, P3::AbstractBSplineSpace)
@@ -304,6 +308,7 @@ function innerproduct_R(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace
     nodes2, weights2 = gausslegendre(nip2)
     nodes3, weights3 = gausslegendre(nip3)
     b = [_f_b_int_R(func, i1, i2, i3, P1, P2, P3, nip1, nip2, nip3, nodes1, nodes2, nodes3, weights1, weights2, weights3) for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3]
+    return b
 end
 
 function innerproduct_I(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace, P3::AbstractBSplineSpace)
@@ -316,6 +321,7 @@ function innerproduct_I(func, P1::AbstractBSplineSpace, P2::AbstractBSplineSpace
     nodes2, weights2 = gausslegendre(nip2)
     nodes3, weights3 = gausslegendre(nip3)
     b = [_f_b_int_I(func, i1, i2, i3, P1, P2, P3, nip1, nip2, nip3, nodes1, nodes2, nodes3, weights1, weights2, weights3) for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3]
+    return b
 end
 
 """

--- a/src/_Integral.jl
+++ b/src/_Integral.jl
@@ -3,7 +3,7 @@
 """
 Integrate on interval
 """
-function integrate(func::Function, I1::ClosedInterval{<:Real}, nip1, nodes1, weights1)
+function integrate(func, I1::ClosedInterval{<:Real}, nip1, nodes1, weights1)
     dnodes1 = (width(I1) * nodes1 .+ sum(extrema(I1))) / 2
 
     S1 = weights1[1] * func(dnodes1[1])
@@ -14,7 +14,7 @@ function integrate(func::Function, I1::ClosedInterval{<:Real}, nip1, nodes1, wei
     return S1 * width(I1) / 2
 end
 
-function integrate(func::Function, I1::ClosedInterval{<:Real}, I2::ClosedInterval{<:Real}, nip1, nip2, nodes1, nodes2, weights1, weights2)
+function integrate(func, I1::ClosedInterval{<:Real}, I2::ClosedInterval{<:Real}, nip1, nip2, nodes1, nodes2, weights1, weights2)
     dnodes1 = (width(I1) * nodes1 .+ sum(extrema(I1))) / 2
     dnodes2 = (width(I2) * nodes2 .+ sum(extrema(I2))) / 2
 
@@ -34,7 +34,7 @@ function integrate(func::Function, I1::ClosedInterval{<:Real}, I2::ClosedInterva
     return S1 * width(I1) * width(I2) / 4
 end
 
-function integrate(func::Function, I1::ClosedInterval{<:Real}, I2::ClosedInterval{<:Real}, I3::ClosedInterval{<:Real}, nip1, nip2, nip3, nodes1, nodes2, nodes3, weights1, weights2, weights3)
+function integrate(func, I1::ClosedInterval{<:Real}, I2::ClosedInterval{<:Real}, I3::ClosedInterval{<:Real}, nip1, nip2, nip3, nodes1, nodes2, nodes3, weights1, weights2, weights3)
     dnodes1 = (width(I1) * nodes1 .+ sum(extrema(I1))) / 2
     dnodes2 = (width(I2) * nodes2 .+ sum(extrema(I2))) / 2
     dnodes3 = (width(I3) * nodes3 .+ sum(extrema(I3))) / 2

--- a/src/_Refinement.jl
+++ b/src/_Refinement.jl
@@ -223,7 +223,7 @@ function refinement(M::AbstractBSplineManifold; p₊::Union{Nothing,AbstractVect
     end
 
     Ps′ = similar(Ps)
-    for i in 1:length(Ps)
+    for i in eachindex(Ps)
         P = Ps[i]
         p = degree(P)
         k = knots(P)


### PR DESCRIPTION
Some progress of performance:
```julia
Random.seed!(42)

p1 = 2
k1 = Knots(rand(3)) + (p1 + 1) * Knots([0, 1])
P1 = FastBSplineSpace(p1, k1)
n1 = dim(P1)
p2 = 1
k2 = Knots(rand(4)) + (p2 + 1) * Knots([0, 1])
P2 = FastBSplineSpace(p2, k2)
n2 = dim(P2)
p3 = 2
k3 = Knots(rand(5)) + (p3 + 1) * Knots([0, 1])
P3 = FastBSplineSpace(p3, k3)
n3 = dim(P3)
a_org = [[i1, i2, i3, rand()] for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3]
M = BSplineSolid([P1, P2, P3], a_org)

p1′ = p1 + 1
k1′ = k1 + unique(k1) + Knots(rand(2))
P1′ = FastBSplineSpace(p1′, k1′)
p2′ = p2 + 1
k2′ = k2 + unique(k2) + Knots(rand(2))
P2′ = FastBSplineSpace(p2′, k2′)
p3′ = p3 + 1
k3′ = k3 + unique(k3) + Knots(rand(2))
P3′ = FastBSplineSpace(p3′, k3′)

M′ = refinement(M, [P1′, P2′, P3′])
a_ref = M′.controlpoints

a_tmp = fittingcontrolpoints(M, [P1′, P2′, P3′])
a_fit = reshape(transpose(hcat(reshape(a_tmp, prod(size(a_tmp)))...)), size(a_tmp)..., 4)

norm(a_fit - a_ref)  # 8.65e-11…

# master
@benchmark fittingcontrolpoints(M, [P1′, P2′, P3′])
```
6.572 s -> 2.885 s
More than twice as fast!

The code above is from `test/runtest.jl`.