### PR TITLE
bugfix for refinement function

### DIFF
--- a/src/_Refinement.jl
+++ b/src/_Refinement.jl
@@ -222,13 +222,7 @@ function refinement(M::AbstractBSplineManifold; p₊::Union{Nothing,AbstractVect
         error("dimension does not match")
     end
 
-    Ps′ = similar(Ps)
-    for i in eachindex(Ps)
-        P = Ps[i]
-        p = degree(P)
-        k = knots(P)
-        Ps′[i] = typeof(Ps[i])(p + p₊[i], k + p₊[i] * unique(k) + k₊[i])
-    end
+    Ps′ = [typeof(Ps[i])(degree(P) + p₊[i], knots(P) + p₊[i] * unique(k) + k₊[i]) for i in eachindex(Ps)]
 
     return refinement(M, Ps′)
 end


### PR DESCRIPTION
Previously, the code below fails.
```julia
using BasicBSpline
p=1
k1=Knots(0,0,1,2,2)
k2=Knots(0,0,1,1)
P1=FastBSplineSpace(p,k1)
P2=FastBSplineSpace(p,k2)
a = [[i1-1,i2] for i1 in 1:dim(P1), i2 in 1:dim(P2)]
M=BSplineSurface([P1,P2],a)
M′=refinement(M, p₊=[1,1])
```
This PR fix this issue.