### PR TITLE
Update type promotions in `bsplinebasis`

### DIFF
--- a/test/test_BSplineBasis.jl
+++ b/test/test_BSplineBasis.jl
@@ -85,4 +85,13 @@ end
             end
         end
     end
+
+    @testset "Rational" begin
+        k = KnotVector{Int}(1:12)
+        P = BSplineSpace{3}(k)
+        @test k isa KnotVector{Int}
+        @test P isa BSplineSpace{3,Int}
+        @test bsplinebasis(P,1,11//5) isa Rational{Int}
+        @test bsplinebasis(P,1,11//5) === bsplinebasis(P,2,16//5) === 106//375
+    end
 end


### PR DESCRIPTION
Before this PR
```julia
julia> p = 3
3

julia> k = KnotVector{Int}(1:12)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])

julia> P = BSplineSpace{p}(k)
BSplineSpace{3, Int64}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))

julia> bsplinebasis(P,1,11//5)
ERROR: MethodError: no method matching bsplinebasis(::BSplineSpace{3, Int64}, ::Int64, ::Rational{Int64})
Closest candidates are:
  bsplinebasis(::BSplineSpace{p, T}, ::Integer, ::T) where {p, T} at ~/.julia/dev/BasicBSpline/src/_BSplineBasis.jl:107
  bsplinebasis(::BSplineDerivativeSpace{r, BSplineSpace{p, T}}, ::Integer, ::Real) where {r, p, T} at ~/.julia/dev/BasicBSpline/src/_DerivativeBasis.jl:73
Stacktrace:
 [1] top-level scope
   @ REPL[5]:1

julia> bsplinebasis(P,2,16//5)
ERROR: MethodError: no method matching bsplinebasis(::BSplineSpace{3, Int64}, ::Int64, ::Rational{Int64})
Closest candidates are:
  bsplinebasis(::BSplineSpace{p, T}, ::Integer, ::T) where {p, T} at ~/.julia/dev/BasicBSpline/src/_BSplineBasis.jl:107
  bsplinebasis(::BSplineDerivativeSpace{r, BSplineSpace{p, T}}, ::Integer, ::Real) where {r, p, T} at ~/.julia/dev/BasicBSpline/src/_DerivativeBasis.jl:73
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1
```

After this PR
```julia
julia> p = 3
3

julia> k = KnotVector{Int}(1:12)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])

julia> P = BSplineSpace{p}(k)
BSplineSpace{3, Int64}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))

julia> bsplinebasis(P,1,11//5)
106//375

julia> bsplinebasis(P,2,16//5)
106//375
```