### PR TITLE
Fix around `zero` methods for `KnotVector`

### DIFF
--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -52,7 +52,7 @@ function KnotVector{T}(knots::Real...) where T<:Real
     return unsafe_knotvector(T, sort!(collect(knots)))
 end
 KnotVector() = unsafe_knotvector(Float64, Float64[])
-KnotVector{T}() where T = unsafe_knotvector(T, T[])
+KnotVector{T}() where T<:Real = unsafe_knotvector(T, T[])
 
 function Base.show(io::IO, k::KnotVector)
     if k.vector == Float64[]

--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -52,6 +52,7 @@ function KnotVector{T}(knots::Real...) where T<:Real
     return unsafe_knotvector(T, sort!(collect(knots)))
 end
 KnotVector() = unsafe_knotvector(Float64, Float64[])
+KnotVector{T}() where T = unsafe_knotvector(T, T[])
 
 function Base.show(io::IO, k::KnotVector)
     if k.vector == Float64[]
@@ -62,6 +63,7 @@ function Base.show(io::IO, k::KnotVector)
 end
 
 Base.zero(::Type{<:KnotVector}) = KnotVector()
+Base.zero(::KnotVector{T}) where T = KnotVector{T}()
 Base.:(==)(k₁::KnotVector, k₂::KnotVector) = (k₁.vector == k₂.vector)
 
 Base.eltype(::KnotVector{T}) where T = T
@@ -114,7 +116,7 @@ KnotVector([1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 5.0, 5.0])
 """
 function Base.:*(m::Integer, k::AbstractKnotVector)
     if m == 0
-        return zero(KnotVector)
+        return zero(k)
     elseif m > 0
         return sum(k for _ in 1:m)
     else

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -21,7 +21,7 @@
 
     @testset "zeros" begin
         @test KnotVector() == zero(KnotVector)
-        @test KnotVector() == 0*k1 == k1*0
+        @test KnotVector() == 0*k1 == k1*0 == zero(k1)
         @test KnotVector() == KnotVector(Float64[])
     end
 
@@ -39,6 +39,9 @@
         # type promotion
         @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) == KnotVector(1,2,3)
         @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) isa KnotVector{Rational{Int}}
+        @test KnotVector{Int}(1,2)*0 == KnotVector()
+        @test KnotVector{Int}(1,2)*0 isa KnotVector{Int}
+        @test KnotVector{Int}() isa KnotVector{Int}
     end
 
     @testset "unique" begin


### PR DESCRIPTION
Before this PR
```julia
julia> using BasicBSpline

julia> k = KnotVector{Int}(0)
KnotVector([0])

julia> 0*k
KnotVector([])

julia> typeof(0*k)
KnotVector{Float64}

julia> typeof(2*k)
KnotVector{Int64}

julia> zero(k)
ERROR: MethodError: no method matching zero(::KnotVector{Int64})
Closest candidates are:
  zero(::Union{Type{P}, P}) where P<:Dates.Period at ~/julia/julia-1.7.0/share/julia/stdlib/v1.7/Dates/src/periods.jl:53
  zero(::AbstractIrrational) at ~/julia/julia-1.7.0/share/julia/base/irrationals.jl:150
  zero(::CartesianIndex{N}) where N at ~/julia/julia-1.7.0/share/julia/base/multidimensional.jl:106
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1
```

After this PR
```julia
julia> using BasicBSpline

julia> k = KnotVector{Int}(0)
KnotVector([0])

julia> 0*k
KnotVector([])

julia> typeof(0*k)
KnotVector{Int64}

julia> typeof(2*k)
KnotVector{Int64}

julia> zero(k)
KnotVector([])
```