### PR TITLE
Faster `fittingcontrolpoints`

### DIFF
--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -107,30 +107,6 @@ function _f_b_int_R(func, i1, i2, P::Tuple{<:AbstractBSplineSpace{p1}, <:Abstrac
     return S1
 end
 
-function _f_b_int_I(func, i1, i2, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}}, gl1, gl2) where {p1,p2}
-    P1, P2 = P
-    k1, k2 = knotvector(P1), knotvector(P2)
-    m1, m2 = length(k1), length(k2)
-    F(t1, t2) = bsplinebasis(P1, i1, t1) * bsplinebasis(P2, i2, t2) * func(t1, t2)
-
-    f1, l1 = max(i1, p1+1), min(i1+p1, m1-p1-1)
-    f2, l2 = max(i2, p2+1), min(i2+p2, m2-p2-1)
-
-    S2 = integrate(F, k1[f1]..k1[f1+1], k2[f2]..k2[f2+1], gl1, gl2)
-    for j2 in f2+1:l2
-        S2 += integrate(F, k1[f1]..k1[f1+1], k2[j2]..k2[j2+1], gl1, gl2)
-    end
-    S1 = S2
-    for j1 in f1+1:l1
-        S2 = integrate(F, k1[j1]..k1[j1+1], k2[f2]..k2[f2+1], gl1, gl2)
-        for j2 in f2+1:l2
-            S2 += integrate(F, k1[j1]..k1[j1+1], k2[j2]..k2[j2+1], gl1, gl2)
-        end
-        S1 += S2
-    end
-    return S1
-end
-
 function _f_b_int_R(func, i1, i2, i3, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}, <:AbstractBSplineSpace{p3}}, gl1, gl2, gl3) where {p1,p2,p3}
     P1, P2, P3 = P
     k1, k2, k3 = knotvector(P1), knotvector(P2), knotvector(P3)
@@ -139,47 +115,6 @@ function _f_b_int_R(func, i1, i2, i3, P::Tuple{<:AbstractBSplineSpace{p1}, <:Abs
     f1, l1 = i1, i1+p1
     f2, l2 = i2, i2+p2
     f3, l3 = i3, i3+p3
-
-    S3 = integrate(F, k1[f1]..k1[f1+1], k2[f2]..k2[f2+1], k3[f3]..k3[f3+1], gl1, gl2, gl3)
-    for j3 in f3+1:l3
-        S3 += integrate(F, k1[f1]..k1[f1+1], k2[f2]..k2[f2+1], k3[j3]..k3[j3+1], gl1, gl2, gl3)
-    end
-    S2 = S3
-    for j2 in f2+1:l2
-        S3 = integrate(F, k1[f1]..k1[f1+1], k2[j2]..k2[j2+1], k3[f3]..k3[f3+1], gl1, gl2, gl3)
-        for j3 in f3+1:l3
-            S3 += integrate(F, k1[f1]..k1[f1+1], k2[j2]..k2[j2+1], k3[j3]..k3[j3+1], gl1, gl2, gl3)
-        end
-        S2 += S3
-    end
-    S1 = S2
-    for j1 in f1+1:l1
-        S3 = integrate(F, k1[j1]..k1[j1+1], k2[f2]..k2[f2+1], k3[f3]..k3[f3+1], gl1, gl2, gl3)
-        for j3 in f3+1:l3
-            S3 += integrate(F, k1[j1]..k1[j1+1], k2[f2]..k2[f2+1], k3[j3]..k3[j3+1], gl1, gl2, gl3)
-        end
-        S2 = S3
-        for j2 in f2+1:l2
-            S3 = integrate(F, k1[j1]..k1[j1+1], k2[j2]..k2[j2+1], k3[f3]..k3[f3+1], gl1, gl2, gl3)
-            for j3 in f3+1:l3
-                S3 += integrate(F, k1[j1]..k1[j1+1], k2[j2]..k2[j2+1], k3[j3]..k3[j3+1], gl1, gl2, gl3)
-            end
-            S2 += S3
-        end
-        S1 += S2
-    end
-    return S1
-end
-
-function _f_b_int_I(func, i1, i2, i3, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}, <:AbstractBSplineSpace{p3}}, gl1, gl2, gl3) where {p1,p2,p3}
-    P1, P2, P3 = P
-    k1, k2, k3 = knotvector(P1), knotvector(P2), knotvector(P3)
-    m1, m2, m3 = length(k1), length(k2), length(k3)
-    F(t1, t2, t3) = bsplinebasis(P1, i1, t1) * bsplinebasis(P2, i2, t2) * bsplinebasis(P3, i3, t3) * func(t1, t2, t3)
-
-    f1, l1 = max(i1, p1+1), min(i1+p1, m1-p1-1)
-    f2, l2 = max(i2, p2+1), min(i2+p2, m2-p2-1)
-    f3, l3 = max(i3, p3+1), min(i3+p3, m3-p3-1)
 
     S3 = integrate(F, k1[f1]..k1[f1+1], k2[f2]..k2[f2+1], k3[f3]..k3[f3+1], gl1, gl2, gl3)
     for j3 in f3+1:l3
@@ -278,6 +213,60 @@ function innerproduct_I(func, Ps::Tuple{<:BSplineSpace{p₁},<:BSplineSpace{p₂
     return b
 end
 
+function innerproduct_I(func, Ps::Tuple{<:BSplineSpace{p₁},<:BSplineSpace{p₂},<:BSplineSpace{p₃}}) where {p₁,p₂,p₃}
+    P₁,P₂,P₃ = Ps
+    n₁,n₂,n₃ = dim.(Ps)
+    k₁,k₂,k₃ = knotvector.(Ps)
+    l₁,l₂,l₃ = length(k₁), length(k₂), length(k₃)
+    nodes₁, weights₁ = SVector{p₁+1}.(gausslegendre(p₁+1))
+    nodes₂, weights₂ = SVector{p₂+1}.(gausslegendre(p₂+1))
+    nodes₃, weights₃ = SVector{p₃+1}.(gausslegendre(p₃+1))
+
+    sample_point = func(leftendpoint(domain(P₁)),leftendpoint(domain(P₂)),leftendpoint(domain(P₃)))
+    b = Array{typeof(sample_point),3}(undef, n₁, n₂, n₃)
+    fill!(b, zero(sample_point))
+
+    for m₁ in 1:l₁-2p₁-1
+        ta₁ = k₁[m₁+p₁]
+        tb₁ = k₁[m₁+p₁+1]
+        w₁ = tb₁-ta₁
+        iszero(w₁) && continue
+        dnodes₁ = (w₁ * nodes₁ .+ (ta₁+tb₁)) / 2
+        bbs₁ = hcat(bsplinebasisall.(P₁,m₁,dnodes₁)...)
+        for m₂ in 1:l₂-2p₂-1
+            ta₂ = k₂[m₂+p₂]
+            tb₂ = k₂[m₂+p₂+1]
+            w₂ = tb₂-ta₂
+            iszero(w₂) && continue
+            dnodes₂ = (w₂ * nodes₂ .+ (ta₂+tb₂)) / 2
+            bbs₂ = hcat(bsplinebasisall.(P₂,m₂,dnodes₂)...)
+            for m₃ in 1:l₃-2p₃-1
+                ta₃ = k₃[m₃+p₃]
+                tb₃ = k₃[m₃+p₃+1]
+                w₃ = tb₃-ta₃
+                iszero(w₃) && continue
+                dnodes₃ = (w₃ * nodes₃ .+ (ta₃+tb₃)) / 2
+                bbs₃ = hcat(bsplinebasisall.(P₃,m₃,dnodes₃)...)
+                # TODO: This can be potentially faster
+                for j in 1:p₃+1
+                    F = func.(dnodes₁,dnodes₂',dnodes₃[j])
+                    for q₁ in 0:p₁
+                        i₁ = m₁ + q₁
+                        for q₂ in 0:p₂
+                            i₂ = m₂ + q₂
+                            for q₃ in 0:p₃
+                                i₃ = m₃ + q₃
+                                b[i₁,i₂,i₃] += sum(F.*bbs₁[i₁-m₁+1,:].*weights₁.*(bbs₂[i₂-m₂+1,:].*weights₂)')*bbs₃[i₃-m₃+1,j]*weights₃[j]*w₁*w₂*w₃/8
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return b
+end
+
 function innerproduct_R(func, Ps::Tuple{<:BSplineSpace{p1}}) where {p1}
     P1, = Ps
     n1 = dim(P1)
@@ -306,19 +295,6 @@ function innerproduct_R(func, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSp
     gl2 = GaussLegendre(nip2)
     gl3 = GaussLegendre(nip3)
     b = [_f_b_int_R(func, i1, i2, i3, P, gl1, gl2, gl3) for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3]
-    return b
-end
-
-function innerproduct_I(func, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}, <:AbstractBSplineSpace{p3}}) where {p1,p2,p3}
-    P1, P2, P3 = P
-    n1, n2, n3 = dim(P1), dim(P2), dim(P3)
-    nip1 = p1 + 1
-    nip2 = p2 + 1
-    nip3 = p3 + 1
-    gl1 = GaussLegendre(nip1)
-    gl2 = GaussLegendre(nip2)
-    gl3 = GaussLegendre(nip3)
-    b = [_f_b_int_I(func, i1, i2, i3, P, gl1, gl2, gl3) for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3]
     return b
 end
 

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -212,7 +212,8 @@ function _f_b_int_I(func, i1, i2, i3, P::Tuple{<:AbstractBSplineSpace{p1}, <:Abs
     return S1
 end
 
-function innerproduct_R(func, P1::BSplineSpace{p1}) where {p1}
+function innerproduct_R(func, Ps::Tuple{<:BSplineSpace{p1}}) where {p1}
+    P1, = Ps
     n1 = dim(P1)
     nip1 = p1 + 1
     gl1 = GaussLegendre(nip1)
@@ -220,7 +221,8 @@ function innerproduct_R(func, P1::BSplineSpace{p1}) where {p1}
     return b
 end
 
-function innerproduct_I(func, P₁::BSplineSpace{p₁}) where {p₁}
+function innerproduct_I(func, Ps::Tuple{<:BSplineSpace{p₁}}) where {p₁}
+    P₁, = Ps
     n₁ = dim(P₁)
     k₁ = knotvector(P₁)
     l₁ = length(k₁)
@@ -297,10 +299,10 @@ end
 function fittingcontrolpoints(func, P::Tuple{<:AbstractBSplineSpace{p1}}; domain=:I) where {p1}
     P1, = P
     if domain == :I
-        b = innerproduct_I(func, P1)
+        b = innerproduct_I(func, P)
         A = innerproduct_I(P1)
     elseif domain == :R
-        b = innerproduct_R(func, P1)
+        b = innerproduct_R(func, P)
         A = innerproduct_R(P1)
     end
     return inv(A) * b

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -50,36 +50,6 @@ function _b_b_int_R(P::BSplineSpace{p}, i, j, gl) where p
     end
 end
 
-@doc raw"""
-Calculate
-```math
-\begin{aligned}
-&\int_{I} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
-\end{aligned}
-```
-"""
-function _b_b_int_I(P::BSplineSpace{p}, i, j, gl) where p
-    n = dim(P)
-    Δ = j - i
-    if Δ < -p
-        return 0.0
-    elseif Δ > p
-        return 0.0
-    elseif Δ ≥ 0  # i ≤ j
-        s = 0.0
-        for m in max(p-j+2,1):min(n-j+1,p-j+i+1)
-            s += _b_b_int(P, i, j, m, gl)
-        end
-        return s
-    else  # j < i
-        s = 0.0
-        for m in max(p-i+2,1):min(n-i+1,p-i+j+1)
-            s += _b_b_int(P, j, i, m, gl)
-        end
-        return s
-    end
-end
-
 function innerproduct_R(P::BSplineSpace{p}) where p
     n = dim(P)
     nip = p + 1
@@ -87,6 +57,14 @@ function innerproduct_R(P::BSplineSpace{p}) where p
     return [_b_b_int_R(P, i, j, gl) for i in 1:n, j in 1:n]
 end
 
+@doc raw"""
+Calculate a matrix
+```math
+\begin{aligned}
+A_{ij}&=\int_{I} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
+\end{aligned}
+```
+"""
 function innerproduct_I(P::BSplineSpace{p}) where p
     n = dim(P)
     A = zeros(n,n)

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -3,55 +3,7 @@
 @doc raw"""
 Calculate a matrix
 ```math
-\begin{aligned}
-A_{ij}&=\int_{\mathbb{R}} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
-\end{aligned}
-```
-"""
-function innerproduct_R(P::BSplineSpace{p}) where p
-    n = dim(P)
-    k = knotvector(P)
-    nodes, weights = SVector{p+1}.(gausslegendre(p+1))
-    _A1 = zeros(p,p)
-    for i in 1:p, j in 1:p
-        j < i && continue
-        for m in 1:p-j+1
-            t1 = k[j+m-1]
-            t2 = k[j+m]
-            width = t2-t1
-            iszero(width) && continue
-            dnodes = (width * nodes .+ (t1+t2)) / 2
-
-            F = bsplinebasis.(P, i, dnodes) .* bsplinebasis.(P, j, dnodes)
-            _A1[i,j] += sum(F .* weights)*width/2
-        end
-    end
-    _A2 = zeros(p,p)
-    for i in 1:p, j in 1:p
-        j < i && continue
-        for m in p-j+2:p-j+i+1
-            t1 = k[j-p+n+m-1]
-            t2 = k[j-p+n+m]
-            width = t2-t1
-            iszero(width) && continue
-            dnodes = (width * nodes .+ (t1+t2)) / 2
-
-            F = bsplinebasis.(P, i-p+n, dnodes) .* bsplinebasis.(P, j-p+n, dnodes)
-            _A2[i,j] += sum(F .* weights)*width/2
-        end
-    end
-    A = innerproduct_I(P).data
-    A[1:p,1:p] += _A1
-    A[n-p+1:n,n-p+1:n] += _A2
-    return Symmetric(A)
-end
-
-@doc raw"""
-Calculate a matrix
-```math
-\begin{aligned}
-A_{ij}&=\int_{I} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
-\end{aligned}
+A_{ij}=\int_{I} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt
 ```
 """
 function innerproduct_I(P::BSplineSpace{p}) where p
@@ -77,6 +29,45 @@ function innerproduct_I(P::BSplineSpace{p}) where p
             end
         end
     end
+    return Symmetric(A)
+end
+
+@doc raw"""
+Calculate a matrix
+```math
+A_{ij}=\int_{\mathbb{R}} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt
+```
+"""
+function innerproduct_R(P::BSplineSpace{p}) where p
+    n = dim(P)
+    A = innerproduct_I(P).data
+    k = knotvector(P)
+    nodes, weights = SVector{p+1}.(gausslegendre(p+1))
+    A1 = zeros(p,p)
+    A2 = zeros(p,p)
+    for i in 1:p, j in 1:p
+        j < i && continue
+        for m in 1:p-j+1
+            t1 = k[j+m-1]
+            t2 = k[j+m]
+            width = t2-t1
+            iszero(width) && continue
+            dnodes = (width * nodes .+ (t1+t2)) / 2
+            F = bsplinebasis.(P, i, dnodes) .* bsplinebasis.(P, j, dnodes)
+            A1[i,j] += sum(F .* weights)*width/2
+        end
+        for m in p-j+2:p-j+i+1
+            t1 = k[j-p+n+m-1]
+            t2 = k[j-p+n+m]
+            width = t2-t1
+            iszero(width) && continue
+            dnodes = (width * nodes .+ (t1+t2)) / 2
+            F = bsplinebasis.(P, i-p+n, dnodes) .* bsplinebasis.(P, j-p+n, dnodes)
+            A2[i,j] += sum(F .* weights)*width/2
+        end
+    end
+    A[1:p,1:p] += A1
+    A[n-p+1:n,n-p+1:n] += A2
     return Symmetric(A)
 end
 

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -226,7 +226,7 @@ function innerproduct_I(func, P₁::BSplineSpace{p₁}) where {p₁}
     l₁ = length(k₁)
     nodes₁, weights₁ = SVector{p₁+1}.(gausslegendre(p₁+1))
 
-    sample_point = func(0.1)
+    sample_point = func(leftendpoint(domain(P₁)))
     b = Array{typeof(sample_point),1}(undef, n₁)
     fill!(b, zero(sample_point))
 

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -76,13 +76,12 @@ function innerproduct_I(P::BSplineSpace{p}) where p
         @inbounds t2 = k[m+p+1]
         width = t2-t1
         iszero(width) && continue
-        dnodes = (width * nodes .+ sum(t1+t2)) / 2
-        bs(t) = bsplinebasisall(P,m,t)
+        dnodes = (width * nodes .+ (t1+t2)) / 2
         bbs = hcat(bsplinebasisall.(P,m,dnodes)...)
         for i in 1:n
             for q in 0:p
                 j = i + q
-                j > n && continue
+                n < j && continue
                 j ≤ m+p || continue
                 m+p+1 ≤ i+p+1 || continue
                 @inbounds A[i,j] += sum(bbs[i-m+1,:].*bbs[j-m+1,:].*weights)*width/2

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -1,55 +1,13 @@
 # Fitting
 
 @doc raw"""
-Calculate
-```math
-\int_{[k_{j+n-1}, k_{j+n}]} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt
-```
-Assumption:
-* ``i ≤ j``
-* ``1 ≤ n ≤ p-j+i+1``
-"""
-function _b_b_int(P::BSplineSpace{p}, i, j, n, gl) where p
-    I = knotvector(P)[j+n-1]..knotvector(P)[j+n]
-
-    f(t) = bsplinebasis(P, i, t) * bsplinebasis(P, j, t)
-    return integrate(f, I, gl)
-end
-
-@doc raw"""
-Calculate
+Calculate a matrix
 ```math
 \begin{aligned}
-&\int_{\mathbb{R}} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
-={}&
-\begin{cases}
-\displaystyle \int_{[k_{j}, k_{i+p+1}]} B_{(i,p,k)}(t)  B_{(j,p,k)}(t) dt & (i \le j) \\
-\displaystyle \int_{[k_{i}, k_{j+p+1}]} B_{(i,p,k)}(t)  B_{(j,p,k)}(t) dt & (j \le i)
-\end{cases}
+A_{ij}&=\int_{\mathbb{R}} B_{(i,p,k)}(t) B_{(j,p,k)}(t) dt \\
 \end{aligned}
 ```
 """
-function _b_b_int_R(P::BSplineSpace{p}, i, j, gl) where p
-    Δ = j - i
-    if Δ < -p
-        return 0.0
-    elseif Δ > p
-        return 0.0
-    elseif Δ ≥ 0  # i ≤ j
-        s = 0.0
-        for n in 1:p-j+i+1
-            s += _b_b_int(P, i, j, n, gl)
-        end
-        return s
-    else  # j < i
-        s = 0.0
-        for n in 1:p-i+j+1
-            s += _b_b_int(P, j, i, n, gl)
-        end
-        return s
-    end
-end
-
 function innerproduct_R(P::BSplineSpace{p}) where p
     n = dim(P)
     k = knotvector(P)

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -71,42 +71,6 @@ function innerproduct_R(P::BSplineSpace{p}) where p
     return Symmetric(A)
 end
 
-function _f_b_int_R(func, i1, P1::BSplineSpace{p1}, gl1) where {p1}
-    k1 = knotvector(P1)
-    F(t1) = bsplinebasis(P1, i1, t1) * func(t1)
-
-    f1,l1 = i1, i1+p1
-
-    S1 = integrate(F, k1[f1]..k1[f1+1], gl1)
-    for j1 in f1+1:l1
-        S1 += integrate(F, k1[j1]..k1[j1+1], gl1)
-    end
-    return S1
-end
-
-function _f_b_int_R(func, i1, i2, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}}, gl1, gl2) where {p1,p2}
-    P1, P2 = P
-    k1, k2 = knotvector(P1), knotvector(P2)
-    F(t1, t2) = bsplinebasis(P1, i1, t1) * bsplinebasis(P2, i2, t2) * func(t1, t2)
-
-    f1, l1 = i1, i1+p1
-    f2, l2 = i2, i2+p2
-
-    S2 = integrate(F, k1[f1]..k1[f1+1], k2[f2]..k2[f2+1], gl1, gl2)
-    for j2 in f2+1:l2
-        S2 += integrate(F, k1[f1]..k1[f1+1], k2[j2]..k2[j2+1], gl1, gl2)
-    end
-    S1 = S2
-    for j1 in f1+1:l1
-        S2 = integrate(F, k1[j1]..k1[j1+1], k2[f2]..k2[f2+1], gl1, gl2)
-        for j2 in f2+1:l2
-            S2 += integrate(F, k1[j1]..k1[j1+1], k2[j2]..k2[j2+1], gl1, gl2)
-        end
-        S1 += S2
-    end
-    return S1
-end
-
 function _f_b_int_R(func, i1, i2, i3, P::Tuple{<:AbstractBSplineSpace{p1}, <:AbstractBSplineSpace{p2}, <:AbstractBSplineSpace{p3}}, gl1, gl2, gl3) where {p1,p2,p3}
     P1, P2, P3 = P
     k1, k2, k3 = knotvector(P1), knotvector(P2), knotvector(P3)

--- a/test/test_Fitting.jl
+++ b/test/test_Fitting.jl
@@ -1,6 +1,26 @@
 @testset "Fitting" begin
     ε = 1.0e-8
 
+    @testset "Fitting_tinycase" begin
+        Random.seed!(42)
+
+        p = 2
+        k = KnotVector(1:2p+2)
+        P = BSplineSpace{p}(k)
+        n = dim(P)
+        @test n == p+1
+        @test IntervalSets.width(domain(P)) == 1
+
+        a_org = [rand() for i in 1:n]
+        M = CustomBSplineManifold(a_org, (P,))
+
+        a_fit = fittingcontrolpoints(M, (P,), domain=:I)
+        @test norm(a_fit - a_org) < ε
+
+        a_fit = fittingcontrolpoints(M, (P,), domain=:R)
+        @test norm(a_fit - a_org) < ε
+    end
+
     @testset "Fitting-curve_R" begin
         Random.seed!(42)
 

--- a/test/test_Fitting.jl
+++ b/test/test_Fitting.jl
@@ -12,12 +12,12 @@
         @test IntervalSets.width(domain(P)) == 1
 
         a_org = [rand() for i in 1:n]
-        M = CustomBSplineManifold(a_org, (P,))
+        f(t) = sum(bsplinebasis(P,i,t)*a_org[i] for i in 1:n)
 
-        a_fit = fittingcontrolpoints(M, (P,), domain=:I)
+        a_fit = fittingcontrolpoints(f, (P,), domain=:I)
         @test norm(a_fit - a_org) < ε
 
-        a_fit = fittingcontrolpoints(M, (P,), domain=:R)
+        a_fit = fittingcontrolpoints(f, (P,), domain=:R)
         @test norm(a_fit - a_org) < ε
     end
 


### PR DESCRIPTION
**On current `master` branch**
```julia
julia> using BasicBSpline, LinearAlgebra, StaticArrays, BenchmarkTools

julia> p = 3;

julia> k = KnotVector(range(-2π,2π,length=32))+p*KnotVector(-2π,2π);

julia> P = BSplineSpace{p}(k);

julia> f(u) = SVector(u,sin(u));

julia> @benchmark fittingcontrolpoints(f, (P,))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  181.162 μs …  1.720 ms  ┊ GC (min … max): 0.00% … 86.38%
 Time  (median):     191.402 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   201.168 μs ± 86.347 μs  ┊ GC (mean ± σ):  2.84% ±  5.79%

     ▂▅▇██▇▆▅▄▃▂▁▁                       ▁▁▁                   ▂
  ▄▄▅██████████████▇▆▆▆▆▆▅▅▅▅▆▅▄▆▅▆▆▇▇▇███████▇▇▆▇▅▅▆▄▅▄▄▃▅▅▄▂ █
  181 μs        Histogram: log(frequency) by time       265 μs <

 Memory estimate: 212.00 KiB, allocs estimate: 1877.

julia> @benchmark BasicBSpline.innerproduct_I(P)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  113.053 μs …  1.365 ms  ┊ GC (min … max): 0.00% … 91.13%
 Time  (median):     118.284 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   123.365 μs ± 67.203 μs  ┊ GC (mean ± σ):  3.06% ±  5.11%

       ▄██▃                                                     
  ▁▁▂▃▇████▆▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  113 μs          Histogram: frequency by time          157 μs <

 Memory estimate: 148.88 KiB, allocs estimate: 1491.
```

**With this PR**

```julia
julia> using BasicBSpline, LinearAlgebra, StaticArrays, BenchmarkTools

julia> p = 3;

julia> k = KnotVector(range(-2π,2π,length=32))+p*KnotVector(-2π,2π);

julia> P = BSplineSpace{p}(k);

julia> f(u) = SVector(u,sin(u));

julia> @benchmark fittingcontrolpoints(f, (P,))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  47.971 μs …  1.512 ms  ┊ GC (min … max): 0.00% … 95.55%
 Time  (median):     50.776 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   52.597 μs ± 34.770 μs  ┊ GC (mean ± σ):  1.82% ±  2.67%

      ▁▅█▇▅▂                                                   
  ▂▂▃▅██████▆▄▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂ ▃
  48 μs           Histogram: frequency by time          70 μs <

 Memory estimate: 37.48 KiB, allocs estimate: 14.

julia> @benchmark BasicBSpline.innerproduct_I(P)
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.949 μs … 343.495 μs  ┊ GC (min … max): 0.00% … 96.38%
 Time  (median):     5.387 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.974 μs ±   9.799 μs  ┊ GC (mean ± σ):  5.85% ±  3.57%

    ▃▄▆▇██▇▆▅▄▄▃▂▂▂▁         ▁▁▁▂▁▁▁▁▁                        ▂
  ▄███████████████████▆▇▆▆▇████████████████▇▇▇█▇▇▇▆▇▅▅▄▅▄▅▅▆▆ █
  4.95 μs      Histogram: log(frequency) by time      8.44 μs <

 Memory estimate: 9.41 KiB, allocs estimate: 4.
```