### PR TITLE
Update around `isdegenerate`

### DIFF
--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -104,10 +104,14 @@ const ⊑ = issqsubset
 
 ≃(P1::AbstractBSplineSpace, P2::AbstractBSplineSpace) = (P1 ⊑ P2) & (P2 ⊑ P1)
 
-function iszeros(P::AbstractBSplineSpace{p}) where p
+function isdegenerate(P::AbstractBSplineSpace{p}, i::Int) where p
     k = knotvector(P)
-    n = dim(P)
-    return [k[i] == k[i+p+1] for i in 1:n]
+    return k[i] == k[i+p+1]
+end
+isnondegenerate(P::AbstractBSplineSpace, i::Int) = !isdegenerate(P, i)
+
+function iszeros(P::AbstractBSplineSpace{p}) where p
+    return [isdegenerate(P,i) for i in 1:dim(P)]
 end
 
 @doc raw"""
@@ -139,11 +143,18 @@ true
 ```
 """
 function isdegenerate(P::AbstractBSplineSpace)
-    return any(iszeros(P))
+    for i in 1:dim(P)
+        isdegenerate(P,i) && return true
+    end
+    return false
 end
 
 function exactdim(P::AbstractBSplineSpace)
-    return dim(P) - sum(iszeros(P))
+    n = dim(P)
+    for i in 1:dim(P)
+        n -= isdegenerate(P,i)
+    end
+    return n
 end
 
 # These bindings will be removed when releasing v0.5.0

--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -110,9 +110,10 @@ function isdegenerate(P::AbstractBSplineSpace{p}, i::Int) where p
 end
 isnondegenerate(P::AbstractBSplineSpace, i::Int) = !isdegenerate(P, i)
 
-function iszeros(P::AbstractBSplineSpace{p}) where p
+function _iszeros(P::AbstractBSplineSpace{p}) where p
     return [isdegenerate(P,i) for i in 1:dim(P)]
 end
+Base.@deprecate_binding iszeros _iszeros true
 
 @doc raw"""
 Check if given B-spline space is non-degenerate.

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -19,14 +19,14 @@ function _changebasis_R(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T})::Matri
         n = length(k) - 1
         n′ = length(k′) - p₊ - 1
         A⁰ = T[bsplinesupport(BSplineSpace{p₊}(k′), j) ⊆ bsplinesupport(BSplineSpace{0}(k), i) for i in 1:n, j in 1:n′]
-        A⁰[:, findall(iszeros(P′))] .= NaN
+        A⁰[:, findall(_iszeros(P′))] .= NaN
         return A⁰
     end
 
     Aᵖ⁻¹ = _changebasis_R(_lower(P), _lower(P′)) # (n+1) × (n′+1) matrix
     n = dim(P)
     n′ = dim(P′)
-    Z = iszeros(_lower(P′))
+    Z = _iszeros(_lower(P′))
     W = findall(Z)
     K′ = [k′[i+p′] - k′[i] for i in 1:n′+1]
     K = [ifelse(k[i+p] ≠ k[i], 1 / (k[i+p] - k[i]), 0.0) for i in 1:n+1]


### PR DESCRIPTION
This PR adds `isdegenerate(P,i)` and deprecates `BasicBSpline.iszeros`.