### PR TITLE
Bump version to `v0.4.2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BasicBSpline"
 uuid = "4c5d9882-2acf-4ea4-9e48-968fd4518195"
 authors = ["hyrodium <hyrodium@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/src/_BSplineManifold.jl
+++ b/src/_BSplineManifold.jl
@@ -9,6 +9,7 @@ struct BSplineManifold{Dim,Deg,T,S<:Tuple,Dim₊₁} <: AbstractBSplineManifold{
     bsplinespaces::S
     controlpoints::Array{T,Dim₊₁}
     function BSplineManifold(a::Array{T,Dim₊₁},Ps::S) where {S<:Tuple,Dim₊₁,T<:Real}
+        @warn "BSplineManifold may be removed in the future release. Please use CustomBSplineManifold instead."
         for P in Ps
             if !(P isa AbstractBSplineSpace)
                 throw(TypeError(:CustomBSplineManifold,AbstractBSplineSpace,P))


### PR DESCRIPTION
Bump version to `v0.4.2`.

This PR also adds a warning for `BSplineManifold`.

* `BSpilneManiold{Dim}` stores control points with a array with `Array{Float64,Dim+1}`. (e.g. `Dim==2` then N₁ × N₂ × d is the dimensions of the array, and its `eltype` is `Float64`.)
* `CustomBSpilneManiold{Dim}` stores control points with a array with `Array{S,Dim}`. (e.g. `Dim==2` then N₁ × N₂ is the dimensions of the array, and its `eltype` is `S`.)

In general, `CustomBSpilneManiold{Dim}` is much more efficient than `BSpilneManiold{Dim}`.
