### PR TITLE
Remove matrix `inv`

### DIFF
--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -110,18 +110,18 @@ function _changebasis_sim(P1::AbstractBSplineSpace{p1,T1}, P2::AbstractBSplineSp
         vvv = [v[1] * (p1-i+1) / (p1+1) + v[i+1] * (i) / (p1+1) for i in 1:p1]
         A1 = [bsplinebasis₊₀(P1,i,t) for i in 1:p1, t in vvv]
         A2 = [bsplinebasis₊₀(P2,i,t) for i in 1:p1, t in vvv]
-        A[1:p1, 1:p1] = A1 * inv(A2)
+        A[1:p1, 1:p1] = A1/A2
         vvv = [v[end-p1+i-1] * (p1-i+1) / (p1+1) + v[end] * (i) / (p1+1) for i in 1:p1]
         A1 = [bsplinebasis₋₀(P1,i,t) for i in n-p1+1:n, t in vvv]
         A2 = [bsplinebasis₋₀(P2,i,t) for i in n-p1+1:n, t in vvv]
-        A[n-p1+1:n, n-p1+1:n] = A1 * inv(A2)
+        A[n-p1+1:n, n-p1+1:n] = A1/A2
         # TODO: Fix above
     else
         # TODO: Fix below
         vvv = [v[1] * (n - i + 1) / (n + 1) + v[end] * (i) / (n + 1) for i in 1:n]
         A1 = [bsplinebasis₋₀(P1,i,t) for i in 1:n, t in vvv]
         A2 = [bsplinebasis₋₀(P2,i,t) for i in 1:n, t in vvv]
-        A = A1 * inv(A2)
+        A = A1/A2
         # TODO: Fix above
     end
     return A

--- a/src/_Fitting.jl
+++ b/src/_Fitting.jl
@@ -334,7 +334,7 @@ function fittingcontrolpoints(func, P::Tuple{<:AbstractBSplineSpace{p1}}; domain
         b = innerproduct_R(func, P)
         A = innerproduct_R(P1)
     end
-    return inv(A) * b
+    return _leftdivision(A, b)
 end
 
 """
@@ -353,7 +353,7 @@ function fittingcontrolpoints(func, P::Tuple{<:AbstractBSplineSpace{p1}, <:Abstr
     A = [A1[i1, j1] * A2[i2, j2] for i1 in 1:n1, i2 in 1:n2, j1 in 1:n1, j2 in 1:n2]
     _A = reshape(A, n1 * n2, n1 * n2)
     _b = reshape(b, n1 * n2)
-    return reshape(inv(_A) * _b, n1, n2)
+    return reshape(_leftdivision(_A, _b), n1, n2)
 end
 
 """
@@ -372,5 +372,5 @@ function fittingcontrolpoints(func, P::Tuple{<:AbstractBSplineSpace{p1}, <:Abstr
     A = [A1[i1, j1] * A2[i2, j2] * A3[i3, j3] for i1 in 1:n1, i2 in 1:n2, i3 in 1:n3, j1 in 1:n1, j2 in 1:n2, j3 in 1:n3]
     _A = reshape(A, n1 * n2 * n3, n1 * n2 * n3)
     _b = reshape(b, n1 * n2 * n3)
-    return reshape(inv(_A) * _b, n1, n2, n3)
+    return reshape(_leftdivision(_A, _b), n1, n2, n3)
 end

--- a/src/_util.jl
+++ b/src/_util.jl
@@ -8,3 +8,8 @@ end
 
 # Euler's triangle number (http://oeis.org/wiki/Eulerian_numbers,_triangle_of)
 eulertriangle(n,k) = sum((-1)^j*binomial(n+1,j)*(k-j+1)^n for j in 0:k)
+
+# Left division function
+_leftdivision(A,b) = inv(A)*b
+_leftdivision(A,b::Number) = A\b
+# TODO: add more methods for left division (e.g. b::Vector{<:SVector})


### PR DESCRIPTION
`inv(A) * b` is less efficient than `A\b`. This PR partially solves this problem.