### PR TITLE
Remove `rand_interval` in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,6 @@ using StaticArrays
 using GeometryBasics
 using Plots
 
-function rand_interval(D::ClosedInterval)
-    a,b = endpoints(D)
-    return a+(b-a)*rand()
-end
-
 @testset "BasicBSpline.jl" begin
     include("test_KnotVector.jl")
     include("test_BSplineSpace.jl")

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -68,7 +68,7 @@
             D = domain(P1)
             n = dim(P1)
             for _ in 1:100
-                t = rand_interval(D)
+                t = rand(D)
                 @test norm(bsplinebasis.(P1,1:n,t) - A*bsplinebasis.(P2,1:n,t), Inf) < 1e-14
             end
         end

--- a/test/test_Derivative.jl
+++ b/test/test_Derivative.jl
@@ -109,7 +109,7 @@
             for r in 0:5
                 dP = BSplineDerivativeSpace{r}(P)
                 for _ in 1:10
-                    t = rand_interval(domain(dP))
+                    t = rand(domain(dP))
                     j = intervalindex(dP,t)
                     B = collect(bsplinebasisall(dP,j,t))
                     @test bsplinebasis.(dP,j:j+p,t) ≈ B

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -46,7 +46,7 @@
             R4 = refinement(R, (P1′,))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
+                t1 = rand(D1)
                 @test M(t1) ≈ R(t1)
                 @test M(t1) ≈ M1(t1)
                 @test M(t1) ≈ M2(t1)
@@ -69,7 +69,7 @@
             R4 = refinement(R, (P1′,))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
+                t1 = rand(D1)
                 @test R(t1) ≈ R1(t1)
                 @test R(t1) ≈ R2(t1)
                 @test R(t1) ≈ R3(t1)
@@ -100,8 +100,8 @@
             R4 = refinement(R, (P1′,P2′))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
-                t2 = rand_interval(D2)
+                t1 = rand(D1)
+                t2 = rand(D2)
                 @test M(t1,t2) ≈ R(t1,t2)
                 @test M(t1,t2) ≈ M1(t1,t2)
                 @test M(t1,t2) ≈ M2(t1,t2)
@@ -125,8 +125,8 @@
             R4 = refinement(R, (P1′,P2′))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
-                t2 = rand_interval(D2)
+                t1 = rand(D1)
+                t2 = rand(D2)
                 @test R(t1,t2) ≈ R1(t1,t2)
                 @test R(t1,t2) ≈ R2(t1,t2)
                 @test R(t1,t2) ≈ R3(t1,t2)
@@ -157,9 +157,9 @@
             R4 = refinement(R, (P1′,P2′,P3′))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
-                t2 = rand_interval(D2)
-                t3 = rand_interval(D3)
+                t1 = rand(D1)
+                t2 = rand(D2)
+                t3 = rand(D3)
                 @test M(t1,t2,t3) ≈ R(t1,t2,t3)
                 @test M(t1,t2,t3) ≈ M1(t1,t2,t3)
                 @test M(t1,t2,t3) ≈ M2(t1,t2,t3)
@@ -183,9 +183,9 @@
             R4 = refinement(R, (P1′,P2′,P3′))
 
             for _ in 1:100
-                t1 = rand_interval(D1)
-                t2 = rand_interval(D2)
-                t3 = rand_interval(D3)
+                t1 = rand(D1)
+                t2 = rand(D2)
+                t3 = rand(D3)
                 @test R(t1,t2,t3) ≈ R1(t1,t2,t3)
                 @test R(t1,t2,t3) ≈ R2(t1,t2,t3)
                 @test R(t1,t2,t3) ≈ R3(t1,t2,t3)


### PR DESCRIPTION
`rand(::ClosedInterval)` was added in https://github.com/JuliaMath/IntervalSets.jl/pull/104.
This PR replaces `rand_interval` with the `rand` method.