### PR TITLE
update `_changebasis_sim` with checking knot position equalities

### DIFF
--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -101,14 +101,17 @@ Assumption:
 function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpace{p,T2}) where {p,T1,T2}
     P1 ≃ P2 || throw(DomainError((P1,P2),"P1 ≃ P2 should be hold."))
     U = StaticArrays.arithmetic_closure(promote_type(T1,T2))
-    n = dim(P1)
+    n = dim(P1)  # == dim(P2)
+    k1 = knotvector(P1)
+    k2 = knotvector(P2)
 
     A = Matrix{U}(I, n, n)
     A1 = _derivatives_at_left(P1)
     A2 = _derivatives_at_left(P2)
     A12 = A1/A2
+    Δ = findlast(iszero, k1[1:p] .== k2[1:p])
     # A12 must be lower-triangular
-    for i in 1:p, j in 1:i
+    for i in 1:Δ, j in 1:i
         A[i, j] = A12[i,j]
     end
     A1 = _derivatives_at_right(P1)

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -101,11 +101,11 @@ Assumption:
 function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpace{p,T2}) where {p,T1,T2}
     P1 ≃ P2 || throw(DomainError((P1,P2),"P1 ≃ P2 should be hold."))
     U = StaticArrays.arithmetic_closure(promote_type(T1,T2))
-    n = dim(P1)     # == dim(P2)
-    l = length(k1)  # == length(k2)
     k1 = knotvector(P1)
     k2 = knotvector(P2)
-
+    n = dim(P1)     # == dim(P2)
+    l = length(k1)  # == length(k2)
+    
     A = Matrix{U}(I, n, n)
 
     A1 = _derivatives_at_left(P1)

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -109,7 +109,11 @@ function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpa
     A1 = _derivatives_at_left(P1)
     A2 = _derivatives_at_left(P2)
     A12 = A1/A2
-    Δ = findlast(iszero, k1[1:p] .== k2[1:p])
+    Δ = p
+    for i in reverse(1:p)
+        k1[i] ≠ k2[i] && break
+        Δ -= 1
+    end
     # A12 must be lower-triangular
     for i in 1:Δ, j in 1:i
         A[i, j] = A12[i,j]

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -107,17 +107,15 @@ function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpa
     A1 = _derivatives_at_left(P1)
     A2 = _derivatives_at_left(P2)
     A12 = A1/A2
-    for i in 1:p, j in 1:p
-        # A12 must be lower-triangular
-        i ≥ j || continue
+    # A12 must be lower-triangular
+    for i in 1:p, j in 1:i
         A[i, j] = A12[i,j]
     end
     A1 = _derivatives_at_right(P1)
     A2 = _derivatives_at_right(P2)
     A12 = A1/A2
-    for i in 1:p, j in 1:p
-        # A12 must be upper-triangular
-        i ≤ j || continue
+    # A12 must be upper-triangular
+    for i in 1:p, j in i:p
         A[n-p+i, n-p+j] = A12[i,j]
     end
     return A

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -101,11 +101,13 @@ Assumption:
 function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpace{p,T2}) where {p,T1,T2}
     P1 ≃ P2 || throw(DomainError((P1,P2),"P1 ≃ P2 should be hold."))
     U = StaticArrays.arithmetic_closure(promote_type(T1,T2))
-    n = dim(P1)  # == dim(P2)
+    n = dim(P1)     # == dim(P2)
+    l = length(k1)  # == length(k2)
     k1 = knotvector(P1)
     k2 = knotvector(P2)
 
     A = Matrix{U}(I, n, n)
+
     A1 = _derivatives_at_left(P1)
     A2 = _derivatives_at_left(P2)
     A12 = A1/A2
@@ -118,13 +120,20 @@ function _changebasis_sim(P1::AbstractBSplineSpace{p,T1}, P2::AbstractBSplineSpa
     for i in 1:Δ, j in 1:i
         A[i, j] = A12[i,j]
     end
+
     A1 = _derivatives_at_right(P1)
     A2 = _derivatives_at_right(P2)
     A12 = A1/A2
-    # A12 must be upper-triangular
-    for i in 1:p, j in i:p
-        A[n-p+i, n-p+j] = A12[i,j]
+    Δ = p
+    for i in l-p+1:l
+        k1[i] ≠ k2[i] && break
+        Δ -= 1
     end
+    # A12 must be upper-triangular
+    for i in 1:Δ, j in i:Δ
+        A[n-Δ+i, n-Δ+j] = A12[i+p-Δ,j+p-Δ]
+    end
+
     return A
 end
 


### PR DESCRIPTION
This PR partially resolves #177.

**Before this PR**

```julia
julia> using BasicBSpline

julia> p = 3
3

julia> P1 = BSplineSpace{p}(KnotVector(1:8))
BSplineSpace{3, Int64}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8]))

julia> P2 = BSplineSpace{p}(KnotVector(2,3,3,4,5,6,7,8))
BSplineSpace{3, Int64}(KnotVector([2, 3, 3, 4, 5, 6, 7, 8]))

julia> BasicBSpline._changebasis_sim(P1,P2)
4×4 Matrix{Float64}:
 0.666667     0.0  0.0   0.0
 0.333333     1.0  0.0  -5.55112e-17
 1.85037e-17  0.0  1.0   0.0
 0.0          0.0  0.0   1.0
```

**After this PR**

```julia
julia> using BasicBSpline

julia> p = 3
3

julia> P1 = BSplineSpace{p}(KnotVector(1:8))
BSplineSpace{3, Int64}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8]))

julia> P2 = BSplineSpace{p}(KnotVector(2,3,3,4,5,6,7,8))
BSplineSpace{3, Int64}(KnotVector([2, 3, 3, 4, 5, 6, 7, 8]))

julia> BasicBSpline._changebasis_sim(P1,P2)
4×4 Matrix{Float64}:
 0.666667  0.0  0.0  0.0
 0.333333  1.0  0.0  0.0
 0.0       0.0  1.0  0.0
 0.0       0.0  0.0  1.0
```