### PR TITLE
Add `frule` and `rrule` for `bsplinebasis₊₀` and `bsplinebasis₋₀`

### DIFF
--- a/src/_ChainRules.jl
+++ b/src/_ChainRules.jl
@@ -21,3 +21,43 @@ function ChainRulesCore.rrule(::typeof(bsplinebasis), P::BSplineSpace, i::Intege
     end
     return (B, bsplinebasis_pullback)
 end
+
+function ChainRulesCore.frule((_, ΔP, Δi, Δt), ::typeof(bsplinebasis₊₀), P::BSplineSpace, i::Integer, t::Real)
+    B = bsplinebasis₊₀(P,i,t)
+    ∂B_∂P = @not_implemented BSPLINESPACE_INFO
+    # ∂B_∂i = NoTangent()
+    ∂B_∂t = bsplinebasis′₊₀(P,i,t)
+    return (B, ∂B_∂P*ΔP + ∂B_∂t*Δt)
+end
+
+function ChainRulesCore.rrule(::typeof(bsplinebasis₊₀), P::BSplineSpace, i::Integer, t::Real)
+    B = bsplinebasis₊₀(P,i,t)
+    # project_t = ProjectTo(t)  # Not sure we need this ProjectTo.
+    function bsplinebasis_pullback(ΔB)
+        P̄ = @not_implemented BSPLINESPACE_INFO
+        ī = NoTangent()
+        t̄ = bsplinebasis′₊₀(P,i,t) * ΔB
+        return (NoTangent(), P̄, ī, t̄)
+    end
+    return (B, bsplinebasis_pullback)
+end
+
+function ChainRulesCore.frule((_, ΔP, Δi, Δt), ::typeof(bsplinebasis₋₀), P::BSplineSpace, i::Integer, t::Real)
+    B = bsplinebasis₋₀(P,i,t)
+    ∂B_∂P = @not_implemented BSPLINESPACE_INFO
+    # ∂B_∂i = NoTangent()
+    ∂B_∂t = bsplinebasis′₋₀(P,i,t)
+    return (B, ∂B_∂P*ΔP + ∂B_∂t*Δt)
+end
+
+function ChainRulesCore.rrule(::typeof(bsplinebasis₋₀), P::BSplineSpace, i::Integer, t::Real)
+    B = bsplinebasis₋₀(P,i,t)
+    # project_t = ProjectTo(t)  # Not sure we need this ProjectTo.
+    function bsplinebasis_pullback(ΔB)
+        P̄ = @not_implemented BSPLINESPACE_INFO
+        ī = NoTangent()
+        t̄ = bsplinebasis′₋₀(P,i,t) * ΔB
+        return (NoTangent(), P̄, ī, t̄)
+    end
+    return (B, bsplinebasis_pullback)
+end

--- a/test/test_ChainRules.jl
+++ b/test/test_ChainRules.jl
@@ -7,6 +7,10 @@
             for i in 1:dim(P)
                 test_frule(bsplinebasis, P, i, t)
                 test_rrule(bsplinebasis, P, i, t)
+                test_frule(bsplinebasis₊₀, P, i, t)
+                test_rrule(bsplinebasis₊₀, P, i, t)
+                test_frule(bsplinebasis₋₀, P, i, t)
+                test_rrule(bsplinebasis₋₀, P, i, t)
             end
         end
     end


### PR DESCRIPTION
This PR partially resolves #265.