### PR TITLE
Deprecate some `KnotVector` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ using StaticArrays
 
 p = 2 # degree of polynomial
 k1 = KnotVector(1:8)     # knot vector
-k2 = KnotVector(rand(7))+(p+1)*KnotVector(1)
+k2 = KnotVector(rand(7))+(p+1)*KnotVector([1])
 P1 = BSplineSpace{p}(k1) # B-spline space
 P2 = BSplineSpace{p}(k2)
 n1 = dim(P1) # dimension of B-spline space
@@ -99,7 +99,7 @@ save_png("2dim.png", M) # save image
 ### Refinement
 #### h-refinemnet
 ```julia
-k₊=(KnotVector(3.3,4.2),KnotVector(0.3,0.5)) # additional knotvectors
+k₊=(KnotVector([3.3,4.2]),KnotVector([0.3,0.5])) # additional knotvectors
 M_h = refinement(M, k₊) # refinement of B-spline manifold
 save_png("2dim_h-refinement.png", M_h) # save image
 ```
@@ -122,8 +122,8 @@ Note that this shape and the last shape are equivalent.
 ```julia
 p1 = 2
 p2 = 2
-k1 = KnotVector(-10:10)+p1*KnotVector(-10,10)
-k2 = KnotVector(-10:10)+p2*KnotVector(-10,10)
+k1 = KnotVector(-10:10)+p1*KnotVector([-10,10])
+k2 = KnotVector(-10:10)+p2*KnotVector([-10,10])
 P1 = BSplineSpace{p1}(k1)
 P2 = BSplineSpace{p2}(k2)
 
@@ -140,8 +140,8 @@ If the knotvector span is too coarse, the approximation will be coarse.
 ```julia
 p1 = 2
 p2 = 2
-k1 = KnotVector(-10:5:10)+p1*KnotVector(-10,10)
-k2 = KnotVector(-10:5:10)+p2*KnotVector(-10,10)
+k1 = KnotVector(-10:5:10)+p1*KnotVector([-10,10])
+k2 = KnotVector(-10:5:10)+p2*KnotVector([-10,10])
 P1 = BSplineSpace{p1}(k1)
 P2 = BSplineSpace{p2}(k2)
 

--- a/docs/src/basicbsplineexporter.md
+++ b/docs/src/basicbsplineexporter.md
@@ -18,7 +18,7 @@ using StaticArrays
 
 p = 2 # degree of polynomial
 k1 = KnotVector(1:8) # knot vector
-k2 = KnotVector(rand(7))+(p+1)*KnotVector(1)
+k2 = KnotVector(rand(7))+(p+1)*KnotVector([1])
 P1 = BSplineSpace{p}(k1) # B-spline space
 P2 = BSplineSpace{p}(k2)
 n1 = dim(P1) # dimension of B-spline space

--- a/docs/src/interpolations.md
+++ b/docs/src/interpolations.md
@@ -15,7 +15,7 @@ using Plots; plotly()
 function interpolate(xs::AbstractVector, fs::AbstractVector{T}) where T
     # Cubic open B-spline space
     p = 3
-    k = KnotVector(xs) + KnotVector(xs[1],xs[end]) * p
+    k = KnotVector(xs) + KnotVector([xs[1],xs[end]]) * p
     P = BSplineSpace{p}(k)
 
     # dimensions
@@ -55,7 +55,7 @@ savefig("interpolation_cubic.html") # hide
 function interpolate_linear(xs::AbstractVector, fs::AbstractVector{T}) where T
     # Linear open B-spline space
     p = 1
-    k = KnotVector(xs) + KnotVector(xs[1],xs[end])
+    k = KnotVector(xs) + KnotVector([xs[1],xs[end]])
     P = BSplineSpace{p}(k)
 
     # dimensions

--- a/docs/src/math-fitting.md
+++ b/docs/src/math-fitting.md
@@ -16,8 +16,8 @@ fittingcontrolpoints
 ```@example math
 p1 = 2
 p2 = 2
-k1 = KnotVector(-10:10)+p1*KnotVector(-10,10)
-k2 = KnotVector(-10:10)+p2*KnotVector(-10,10)
+k1 = KnotVector(-10:10)+p1*KnotVector([-10,10])
+k2 = KnotVector(-10:10)+p2*KnotVector([-10,10])
 P1 = BSplineSpace{p1}(k1)
 P2 = BSplineSpace{p2}(k2)
 

--- a/docs/src/math-knotvector.md
+++ b/docs/src/math-knotvector.md
@@ -23,11 +23,11 @@ KnotVector
 ```
 
 ```@docs
-KnotVector(knot::Real)
+UniformKnotVector
 ```
 
 ```@docs
-UniformKnotVector
+EmptyKnotVector
 ```
 
 ## Operations for knot vectors

--- a/docs/src/math-refinement.md
+++ b/docs/src/math-refinement.md
@@ -30,7 +30,7 @@ nothing # hide
 Insert additional knots to knot vector.
 
 ```@repl math
-k₊ = (KnotVector(3.3,4.2),KnotVector(3.8,3.2,5.3)) # additional knotvectors
+k₊ = (KnotVector([3.3,4.2]),KnotVector([3.8,3.2,5.3])) # additional knotvectors
 M_h = refinement(M, k₊) # refinement of B-spline manifold
 save_png("2dim_h-refinement.png", M_h) # save image
 ```

--- a/docs/src/plotlyjs.md
+++ b/docs/src/plotlyjs.md
@@ -8,7 +8,7 @@ using StaticArrays
 using PlotlyJS
 f(t) = SVector((1+cos(t))*cos(t),(1+cos(t))*sin(t))
 p = 3
-k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector(π)
+k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector([π])
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))

--- a/docs/src/plotlyjs.md
+++ b/docs/src/plotlyjs.md
@@ -8,7 +8,7 @@ using StaticArrays
 using PlotlyJS
 f(t) = SVector((1+cos(t))*cos(t),(1+cos(t))*sin(t))
 p = 3
-k = KnotVector(range(0,2π,15)) + p * KnotVector(0,2π) + 2 * KnotVector(π)
+k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector(π)
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))
@@ -36,7 +36,7 @@ using StaticArrays
 using PlotlyJS
 f(t) = SVector(cos(t),sin(t),t)
 p = 3
-k = KnotVector(range(0,6π,15)) + p * KnotVector(0,6π)
+k = KnotVector(range(0,6π,15)) + p * KnotVector([0,6π])
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))

--- a/docs/src/plots.md
+++ b/docs/src/plots.md
@@ -75,7 +75,7 @@ savefig("plots-bsplinebasisderivative.html") # hide
 ```@example plots
 f(t) = SVector((1+cos(t))*cos(t),(1+cos(t))*sin(t))
 p = 3
-k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector(π)
+k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector([π])
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))

--- a/docs/src/plots.md
+++ b/docs/src/plots.md
@@ -75,7 +75,7 @@ savefig("plots-bsplinebasisderivative.html") # hide
 ```@example plots
 f(t) = SVector((1+cos(t))*cos(t),(1+cos(t))*sin(t))
 p = 3
-k = KnotVector(range(0,2π,15)) + p * KnotVector(0,2π) + 2 * KnotVector(π)
+k = KnotVector(range(0,2π,15)) + p * KnotVector([0,2π]) + 2 * KnotVector(π)
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))
@@ -92,7 +92,7 @@ savefig("plots-cardioid.html") # hide
 ```@example plots
 f(t) = SVector(cos(t),sin(t),t)
 p = 3
-k = KnotVector(range(0,6π,15)) + p * KnotVector(0,6π)
+k = KnotVector(range(0,6π,15)) + p * KnotVector([0,6π])
 P = BSplineSpace{p}(k)
 a = fittingcontrolpoints(f,(P,))
 M = BSplineManifold(a, (P,))

--- a/src/BasicBSpline.jl
+++ b/src/BasicBSpline.jl
@@ -8,7 +8,7 @@ using FastGaussQuadrature
 using ChainRulesCore
 
 # Types
-export AbstractKnotVector, KnotVector, UniformKnotVector
+export AbstractKnotVector, KnotVector, UniformKnotVector, EmptyKnotVector
 export AbstractBSplineSpace, BSplineSpace, UniformBSplineSpace
 export AbstractBSplineManifold, BSplineManifold, RationalBSplineManifold
 export BSplineDerivativeSpace

--- a/src/_BSplineManifold.jl
+++ b/src/_BSplineManifold.jl
@@ -16,7 +16,7 @@ Construct B-spline manifold from given control points and B-spline spaces.
 ```jldoctest
 julia> using StaticArrays
 
-julia> P = BSplineSpace{2}(KnotVector(0,0,0,1,1,1))
+julia> P = BSplineSpace{2}(KnotVector([0,0,0,1,1,1]))
 BSplineSpace{2, Int64}(KnotVector([0, 0, 0, 1, 1, 1]))
 
 julia> a = [SVector(1,0), SVector(1,1), SVector(0,1)]

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -178,8 +178,8 @@ function _changebasis_I(P::AbstractBSplineSpace{p,T}, P′::AbstractBSplineSpace
     k = knotvector(P)
     k′ = knotvector(P′)
 
-    _P = BSplineSpace{p}(k[1+p:end-p] + p * KnotVector{T}(k[1+p], k[end-p]))
-    _P′ = BSplineSpace{p′}(k′[1+p′:end-p′] + p′ * KnotVector{T′}(k′[1+p′], k′[end-p′]))
+    _P = BSplineSpace{p}(k[1+p:end-p] + p * KnotVector{T}([k[1+p], k[end-p]]))
+    _P′ = BSplineSpace{p′}(k′[1+p′:end-p′] + p′ * KnotVector{T′}([k′[1+p′], k′[end-p′]]))
     _A = _changebasis_R(_P, _P′)
     Asim = _changebasis_sim(P, _P)
     Asim′ = _changebasis_sim(_P′, P′)

--- a/src/_EmptyKnotVector.jl
+++ b/src/_EmptyKnotVector.jl
@@ -7,13 +7,11 @@ This struct is intended for internal use.
 
 # Examples
 ```jldoctest
-julia> import BasicBSpline.EmptyKnotVector
-
 julia> EmptyKnotVector()
-BasicBSpline.EmptyKnotVector{Bool}()
+EmptyKnotVector{Bool}()
 
 julia> EmptyKnotVector{Float64}()
-BasicBSpline.EmptyKnotVector{Float64}()
+EmptyKnotVector{Float64}()
 ```
 """
 struct EmptyKnotVector{T} <: AbstractKnotVector{T} end

--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -45,18 +45,18 @@ Construct knot vector from given real numbers.
 julia> k = KnotVector([1,2,3])
 KnotVector([1, 2, 3])
 
-julia> k = KnotVector()
+julia> k = KnotVector(Float64[])
 KnotVector([])
 ```
 """
-function KnotVector(knots::Real...)
-    return KnotVector(collect(promote(knots...)))
-end
-function KnotVector{T}(knots::Real...) where T<:Real
-    return unsafe_knotvector(T, sort!(collect(knots)))
-end
-KnotVector() = unsafe_knotvector(Float64, Float64[])
-KnotVector{T}() where T<:Real = unsafe_knotvector(T, T[])
+# function KnotVector(knots::Real...)
+#     return KnotVector(collect(promote(knots...)))
+# end
+# function KnotVector{T}(knots::Real...) where T<:Real
+#     return unsafe_knotvector(T, sort!(collect(knots)))
+# end
+# KnotVector() = unsafe_knotvector(Float64, Float64[])
+# KnotVector{T}() where T<:Real = unsafe_knotvector(T, T[])
 
 function Base.show(io::IO, k::KnotVector)
     if k.vector == Float64[]
@@ -77,8 +77,9 @@ _vec
 
 _vec(k::KnotVector) = k.vector
 
-Base.zero(::Type{<:KnotVector}) = KnotVector()
-Base.zero(::KnotVector{T}) where T = KnotVector{T}()
+Base.zero(::Type{KnotVector}) = zero(KnotVector{Float64})
+Base.zero(::Type{KnotVector{T}}) where T = unsafe_knotvector(T, T[])
+Base.zero(::KnotVector{T}) where T = unsafe_knotvector(T, T[])
 Base.:(==)(k₁::AbstractKnotVector, k₂::AbstractKnotVector) = (_vec(k₁) == _vec(k₂))
 
 Base.eltype(::AbstractKnotVector{T}) where T = T

--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -55,11 +55,7 @@ function KnotVector{T}() where T<:Real
 end
 
 function Base.show(io::IO, k::KnotVector)
-    if k.vector == Float64[]
-        print(io, "KnotVector([])")
-    else
-        print(io, "KnotVector($(k.vector))")
-    end
+    print(io, "KnotVector($(k.vector))")
 end
 
 function Base.show(io::IO, k::T) where T<:AbstractKnotVector

--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -37,26 +37,22 @@ function Base.promote_rule(::Type{KnotVector{T}}, ::Type{KnotVector{S}}) where {
     KnotVector{promote_type(T,S)}
 end
 
-@doc raw"""
-Construct knot vector from given real numbers.
-
-# Examples
-```jldoctest
-julia> k = KnotVector([1,2,3])
-KnotVector([1, 2, 3])
-
-julia> k = KnotVector(Float64[])
-KnotVector([])
-```
-"""
-# function KnotVector(knots::Real...)
-#     return KnotVector(collect(promote(knots...)))
-# end
-# function KnotVector{T}(knots::Real...) where T<:Real
-#     return unsafe_knotvector(T, sort!(collect(knots)))
-# end
-# KnotVector() = unsafe_knotvector(Float64, Float64[])
-# KnotVector{T}() where T<:Real = unsafe_knotvector(T, T[])
+function KnotVector(knots::Real...)
+    Base.depwarn("Method calls such as `KnotVector(1,2,3)` is deprecated. Use `KnotVector([1,2,3])` instead.", :KnotVector)
+    return KnotVector(collect(promote(knots...)))
+end
+function KnotVector{T}(knots::Real...) where T<:Real
+    Base.depwarn("Method calls such as `KnotVector(1,2,3)` is deprecated. Use `KnotVector([1,2,3])` instead.", :KnotVector)
+    return unsafe_knotvector(T, sort!(collect(knots)))
+end
+function KnotVector()
+    Base.depwarn("KnotVector() is deprecated. Use EmptyKnotVector() instead.", :KnotVector)
+    unsafe_knotvector(Float64, Float64[])
+end
+function KnotVector{T}() where T<:Real
+    Base.depwarn("KnotVector{$T}() is deprecated. Use EmptyKnotVector{$T}() or KnotVector($T[]) instead.", :KnotVector)
+    unsafe_knotvector(T, T[])
+end
 
 function Base.show(io::IO, k::KnotVector)
     if k.vector == Float64[]

--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -42,7 +42,7 @@ Construct knot vector from given real numbers.
 
 # Examples
 ```jldoctest
-julia> k = KnotVector(1,2,3)
+julia> k = KnotVector([1,2,3])
 KnotVector([1, 2, 3])
 
 julia> k = KnotVector()
@@ -100,9 +100,9 @@ For example, ``(1,2,3,5)+(4,5,8)=(1,2,3,4,5,5,8)``.
 
 # Examples
 ```jldoctest
-julia> k1 = KnotVector(1,2,3,5);
+julia> k1 = KnotVector([1,2,3,5]);
 
-julia> k2 = KnotVector(4,5,8);
+julia> k2 = KnotVector([4,5,8]);
 
 julia> k1 + k2
 KnotVector([1, 2, 3, 4, 5, 5, 8])
@@ -124,7 +124,7 @@ For example, ``2\cdot (1,2,2,5)=(1,1,2,2,2,2,5,5)``.
 
 # Examples
 ```jldoctest
-julia> k = KnotVector(1,2,2,5);
+julia> k = KnotVector([1,2,2,5]);
 
 julia> 2 * k
 KnotVector([1, 1, 2, 2, 2, 2, 5, 5])
@@ -159,7 +159,7 @@ For example, ``\#{(1,2,2,3)}=4``.
 
 # Examples
 ```jldoctest
-julia> k = KnotVector(1,2,2,3);
+julia> k = KnotVector([1,2,2,3]);
 
 julia> length(k)
 4
@@ -210,13 +210,13 @@ Check a inclusive relationship ``k\subseteq k'``, for example:
 
 # Examples
 ```jldoctest
-julia> KnotVector(1,2) ⊆ KnotVector(1,2,3)
+julia> KnotVector([1,2]) ⊆ KnotVector([1,2,3])
 true
 
-julia> KnotVector(1,2,2) ⊆ KnotVector(1,2,3)
+julia> KnotVector([1,2,2]) ⊆ KnotVector([1,2,3])
 false
 
-julia> KnotVector(1,2,3) ⊆ KnotVector(1,2,3)
+julia> KnotVector([1,2,3]) ⊆ KnotVector([1,2,3])
 true
 ```
 """

--- a/src/_RationalBSplineManifold.jl
+++ b/src/_RationalBSplineManifold.jl
@@ -8,7 +8,7 @@ Construct Rational B-spline manifold from given control points, weights and B-sp
 ```jldoctest
 julia> using StaticArrays, LinearAlgebra
 
-julia> P = BSplineSpace{2}(KnotVector(0,0,0,1,1,1))
+julia> P = BSplineSpace{2}(KnotVector([0,0,0,1,1,1]))
 BSplineSpace{2, Int64}(KnotVector([0, 0, 0, 1, 1, 1]))
 
 julia> w = [1, 1/√2, 1]

--- a/src/_UniformKnotVector.jl
+++ b/src/_UniformKnotVector.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-Construct knot vector from given range.
+Construct uniform knot vector from given range.
 ```math
 k=(k_1,\dots,k_l)
 ```

--- a/test/test_BSplineBasis.jl
+++ b/test/test_BSplineBasis.jl
@@ -18,7 +18,7 @@ end
         Random.seed!(42)
 
         v = rand(10)
-        k = KnotVector(v) + (p+1)*KnotVector([0, 1]) + KnotVector(v[2], v[3])
+        k = KnotVector(v) + (p+1)*KnotVector([0, 1]) + KnotVector(v[2:3])
         P = BSplineSpace{p}(k)
         n = dim(P)
 

--- a/test/test_BSplineBasis.jl
+++ b/test/test_BSplineBasis.jl
@@ -18,7 +18,7 @@ end
         Random.seed!(42)
 
         v = rand(10)
-        k = KnotVector(v) + (p+1)*KnotVector(0, 1) + KnotVector(v[2], v[3])
+        k = KnotVector(v) + (p+1)*KnotVector([0, 1]) + KnotVector(v[2], v[3])
         P = BSplineSpace{p}(k)
         n = dim(P)
 
@@ -124,7 +124,7 @@ end
     @testset "Endpoints" begin
         p = 2
 
-        k = KnotVector(1:2) + (p+1)*KnotVector(0,3)
+        k = KnotVector(1:2) + (p+1)*KnotVector([0,3])
         P0 = BSplineSpace{0}(k)
         P1 = BSplineSpace{1}(k)
         P2 = BSplineSpace{2}(k)

--- a/test/test_BSplineManifold.jl
+++ b/test/test_BSplineManifold.jl
@@ -30,7 +30,7 @@
 
             P1′ = BSplineSpace{2}(KnotVector([-2, 0, 0, 1, 1, 2]))
             p₊ = (Val(1),)
-            k₊ = (KnotVector(),)
+            k₊ = (KnotVector(Float64[]),)
 
             @test P1 ⊑ P1′
 
@@ -65,7 +65,7 @@
             P1′ = BSplineSpace{2}(KnotVector([0, 0, 0, 1, 1, 1]))
             P2′ = BSplineSpace{1}(KnotVector([1, 1, 2, 1.45, 3, 3]))
             p₊ = (Val(1), Val(0))
-            k₊ = (KnotVector(), KnotVector(1.45))
+            k₊ = (KnotVector(Float64[]), KnotVector([1.45]))
 
             @test P1 ⊆ P1′
             @test P2 ⊆ P2′
@@ -103,7 +103,7 @@
             @test dim(M) == 3
 
             p₊ = (Val(1), Val(0), Val(1))
-            k₊ = (KnotVector(), KnotVector(1.45), KnotVector())
+            k₊ = (KnotVector(Float64[]), KnotVector([1.45]), EmptyKnotVector())
 
             M′′ = refinement(M, p₊, k₊)
             ts = [[rand(), 1 + 2 * rand(), 0.5] for _ in 1:10]

--- a/test/test_BSplineSpace.jl
+++ b/test/test_BSplineSpace.jl
@@ -38,7 +38,7 @@
         @test dim(P2) == 4
         @test exactdim(P2) == 3
 
-        P3 = BSplineSpace{2}(KnotVector(0,0,0,1,1,1,2))
+        P3 = BSplineSpace{2}(KnotVector([0,0,0,1,1,1,2]))
         @test domain(P3) == 0..1
         @test dim(P3) == 4
         @test exactdim(P3) == 4
@@ -114,10 +114,10 @@
     end
 
     @testset "expandspace" begin
-        P1 = BSplineSpace{1}(KnotVector(0,0,0,0,0))
+        P1 = BSplineSpace{1}(KnotVector([0,0,0,0,0]))
         P2 = BSplineSpace{3}(KnotVector(1:8))
         P3 = BSplineSpace{2}(KnotVector(1:8)+3*KnotVector(0))
-        P4 = BSplineSpace{2}(KnotVector(0,0,0,1,1,1,2))
+        P4 = BSplineSpace{2}(KnotVector([0,0,0,1,1,1,2]))
 
         @test P1 == expandspace_R(P1) == expandspace_I(P1) == expandspace(P1)
         @test P2 == expandspace_R(P2) == expandspace_I(P2) == expandspace(P2)
@@ -181,8 +181,8 @@
     end
 
     @testset "sqsubset but not subset" begin
-        P6 = BSplineSpace{2}(KnotVector(1,2,3,4,5,6,7))
-        P7 = BSplineSpace{2}(KnotVector(0,1,3,4,5,8,9))
+        P6 = BSplineSpace{2}(KnotVector([1,2,3,4,5,6,7]))
+        P7 = BSplineSpace{2}(KnotVector([0,1,3,4,5,8,9]))
         @test P6 ⊑ P7
         @test P7 ⊑ P6
         @test P6 ≃ P7

--- a/test/test_BSplineSpace.jl
+++ b/test/test_BSplineSpace.jl
@@ -116,7 +116,7 @@
     @testset "expandspace" begin
         P1 = BSplineSpace{1}(KnotVector([0,0,0,0,0]))
         P2 = BSplineSpace{3}(KnotVector(1:8))
-        P3 = BSplineSpace{2}(KnotVector(1:8)+3*KnotVector(0))
+        P3 = BSplineSpace{2}(KnotVector(1:8)+3*KnotVector([0]))
         P4 = BSplineSpace{2}(KnotVector([0,0,0,1,1,1,2]))
 
         @test P1 == expandspace_R(P1) == expandspace_I(P1) == expandspace(P1)

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -58,7 +58,7 @@
     @testset "changebasis_sim" begin
         for p in 1:3, L in 1:8
             k1 = UniformKnotVector(1:L+2p+1)
-            k2 = UniformKnotVector(p+1:p+L+1) + p*KnotVector(p+1) + KnotVector(p+L+1:2p+L)
+            k2 = UniformKnotVector(p+1:p+L+1) + p*KnotVector([p+1]) + KnotVector(p+L+1:2p+L)
             P1 = UniformBSplineSpace{p}(k1)
             P2 = BSplineSpace{p}(k2)
             @test domain(P1) == domain(P2)

--- a/test/test_Derivative.jl
+++ b/test/test_Derivative.jl
@@ -29,7 +29,7 @@
     # Not sure why this @testset doesn't work fine.
     # @testset "$(p)-th degree basis" for p in 0:p_max
     for p in 0:p_max
-        k = KnotVector(rand(20)) + (p+1)*KnotVector(0,1)
+        k = KnotVector(rand(20)) + (p+1)*KnotVector([0,1])
         P = BSplineSpace{p}(k)
         P0 = BSplineDerivativeSpace{0}(P)
         for t in ts, i in 1:dim(P)
@@ -172,7 +172,7 @@
     @testset "Endpoints" begin
         p = 2
 
-        k = KnotVector(1:2) + (p+1)*KnotVector(0,3)
+        k = KnotVector(1:2) + (p+1)*KnotVector([0,3])
         P0 = BSplineSpace{0}(k)
         P1 = BSplineSpace{1}(k)
         P2 = BSplineSpace{2}(k)

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -141,7 +141,8 @@
     @testset "string" begin
         k = KnotVector([1,2,2,3])
         @test string(k) == "KnotVector([1, 2, 2, 3])"
-        @test string(KnotVector(Float64[])) == "KnotVector([])"
+        @test string(KnotVector(Float64[])) == "KnotVector(Float64[])"
+        @test string(KnotVector(Int[])) == "KnotVector(Int64[])"
     end
 
     @testset "other operators" begin

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -14,8 +14,8 @@
         @test k1.vector !== copy(k1).vector
 
         @test KnotVector{Int}([1,2]) isa KnotVector{Int}
-        @test KnotVector{Int}(1,2) isa KnotVector{Int}
-        @test KnotVector{Int}(1,2.) isa KnotVector{Int}
+        @test KnotVector{Int}([1,2]) isa KnotVector{Int}
+        @test KnotVector{Int}([1,2.]) isa KnotVector{Int}
         @test KnotVector{Int}(k1) isa KnotVector{Int}
         @test KnotVector(k1) isa KnotVector{Int}
         @test AbstractKnotVector{Float64}(k1) isa KnotVector{Float64}
@@ -41,16 +41,16 @@
     end
 
     @testset "zeros" begin
-        @test KnotVector() == zero(KnotVector)
-        @test KnotVector() == 0*k1 == k1*0 == zero(k1)
-        @test KnotVector() == KnotVector(Float64[])
-        @test KnotVector() == EmptyKnotVector()
-        @test KnotVector() |> isempty
-        @test KnotVector() |> iszero
+        @test KnotVector(Float64[]) == zero(KnotVector)
+        @test KnotVector(Float64[]) == 0*k1 == k1*0 == zero(k1)
+        @test KnotVector(Float64[]) == EmptyKnotVector()
+        @test KnotVector(Float64[]) |> isempty
+        @test KnotVector(Float64[]) |> iszero
+        # @test KnotVector() this shold be return error
         @test EmptyKnotVector() |> isempty
         @test EmptyKnotVector() |> iszero
-        @test EmptyKnotVector() == KnotVector()
-        @test KnotVector() == EmptyKnotVector()
+        @test EmptyKnotVector() == KnotVector(Float64[])
+        @test KnotVector(Float64[]) == EmptyKnotVector()
         @test EmptyKnotVector{Bool}() === EmptyKnotVector() === zero(EmptyKnotVector) === zero(EmptyKnotVector{Bool})
         @test EmptyKnotVector{Int}() == EmptyKnotVector()
         @test EmptyKnotVector{Int}() == EmptyKnotVector{Int}()
@@ -65,7 +65,7 @@
     end
 
     @testset "length" begin
-        @test length(KnotVector()) == 0
+        @test length(KnotVector(Float64[])) == 0
         @test length(KnotVector([1,2,2,3])) == 4
     end
 
@@ -107,13 +107,13 @@
         @test_throws DomainError EmptyKnotVector()*(-1)
 
         # type promotion
-        @test KnotVector{Int}(1,2) + KnotVector(3) == KnotVector([1,2,3])
-        @test KnotVector{Int}(1,2) + KnotVector(3) isa KnotVector{Int}
-        @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) == KnotVector([1,2,3])
-        @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) isa KnotVector{Rational{Int}}
-        @test KnotVector{Int}(1,2)*0 == KnotVector()
-        @test KnotVector{Int}(1,2)*0 isa KnotVector{Int}
-        @test KnotVector{Int}() isa KnotVector{Int}
+        @test KnotVector{Int}([1,2]) + KnotVector([3]) == KnotVector([1,2,3])
+        @test KnotVector{Int}([1,2]) + KnotVector([3]) isa KnotVector{Int}
+        @test KnotVector{Int}([1,2]) + KnotVector{Rational{Int}}([3]) == KnotVector([1,2,3])
+        @test KnotVector{Int}([1,2]) + KnotVector{Rational{Int}}([3]) isa KnotVector{Rational{Int}}
+        @test KnotVector{Int}([1,2])*0 == KnotVector(Float64[])
+        @test KnotVector{Int}([1,2])*0 isa KnotVector{Int}
+        @test KnotVector{Int}(Int[]) isa KnotVector{Int}
     end
 
     @testset "unique" begin
@@ -131,17 +131,17 @@
         @test KnotVector([1,2,3,5])   ⊉ KnotVector([1,2,2,3])
 
         @test !(KnotVector([1,2,3,4]) ⊊ KnotVector([1,2,3]))
-        @test !(KnotVector([1,2,3]) ⊊ KnotVector([1,2,3]))
-        @test KnotVector([1,2,3]) ⊊ KnotVector([1,2,3,4])
-        @test !(KnotVector([1,2,3]) ⊋ KnotVector([1,2,3,4]))
-        @test !(KnotVector([1,2,3]) ⊋ KnotVector([1,2,3]))
-        @test KnotVector([1,2,3,4]) ⊋ KnotVector([1,2,3])
+        @test !(KnotVector([1,2,3])   ⊊ KnotVector([1,2,3]))
+        @test KnotVector([1,2,3])     ⊊ KnotVector([1,2,3,4])
+        @test !(KnotVector([1,2,3])   ⊋ KnotVector([1,2,3,4]))
+        @test !(KnotVector([1,2,3])   ⊋ KnotVector([1,2,3]))
+        @test KnotVector([1,2,3,4])   ⊋ KnotVector([1,2,3])
     end
 
     @testset "string" begin
         k = KnotVector([1,2,2,3])
         @test string(k) == "KnotVector([1, 2, 2, 3])"
-        @test string(KnotVector()) == "KnotVector([])"
+        @test string(KnotVector(Float64[])) == "KnotVector([])"
     end
 
     @testset "other operators" begin

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -160,11 +160,11 @@
         @test_deprecated KnotVector(1,2)
         @test_deprecated KnotVector{Int}(1,2)
 
-        iszero(KnotVector())
-        iszero(KnotVector{Int}())
-        KnotVector() isa KnotVector{Float64}
-        KnotVector{Int}() isa KnotVector{Int}
-        KnotVector(1,2) == KnotVector([1,2])
-        KnotVector{Int}(1,2) == KnotVector([1,2])
+        @test iszero(KnotVector())
+        @test iszero(KnotVector{Int}())
+        @test KnotVector() isa KnotVector{Float64}
+        @test KnotVector{Int}() isa KnotVector{Int}
+        @test KnotVector(1,2) == KnotVector([1,2])
+        @test KnotVector{Int}(1,2) == KnotVector([1,2])
     end
 end

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -159,5 +159,12 @@
         @test_deprecated KnotVector{Int}()
         @test_deprecated KnotVector(1,2)
         @test_deprecated KnotVector{Int}(1,2)
+
+        iszero(KnotVector())
+        iszero(KnotVector{Int}())
+        KnotVector() isa KnotVector{Float64}
+        KnotVector{Int}() isa KnotVector{Int}
+        KnotVector(1,2) == KnotVector([1,2])
+        KnotVector{Int}(1,2) == KnotVector([1,2])
     end
 end

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -153,4 +153,11 @@
         @test 1 ∈ k
         @test 1.5 ∉ k
     end
+
+    @testset "deprecated" begin
+        @test_deprecated KnotVector()
+        @test_deprecated KnotVector{Int}()
+        @test_deprecated KnotVector(1,2)
+        @test_deprecated KnotVector{Int}(1,2)
+    end
 end

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -6,10 +6,10 @@
         @test k1 isa KnotVector{Int64}
         @test k1 == KnotVector(1:3)::KnotVector{Int}
         @test k1 == KnotVector([1,3,2])::KnotVector{Int64}
-        @test k1 == KnotVector(1,2,3)::KnotVector{Int64}
-        @test k1 == KnotVector(1,3,2)::KnotVector{Int64}
-        @test k1 == KnotVector(1.,3,2)::KnotVector{Float64}
-        @test k1 == KnotVector{Int}(1,3,2)::KnotVector{Int}
+        @test k1 == KnotVector([1,2,3])::KnotVector{Int64}
+        @test k1 == KnotVector([1,3,2])::KnotVector{Int64}
+        @test k1 == KnotVector([1.,3,2])::KnotVector{Float64}
+        @test k1 == KnotVector{Int}([1,3,2])::KnotVector{Int}
         @test k1 != k2
         @test k1.vector !== copy(k1).vector
 
@@ -107,9 +107,9 @@
         @test_throws DomainError EmptyKnotVector()*(-1)
 
         # type promotion
-        @test KnotVector{Int}(1,2) + KnotVector(3) == KnotVector(1,2,3)
+        @test KnotVector{Int}(1,2) + KnotVector(3) == KnotVector([1,2,3])
         @test KnotVector{Int}(1,2) + KnotVector(3) isa KnotVector{Int}
-        @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) == KnotVector(1,2,3)
+        @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) == KnotVector([1,2,3])
         @test KnotVector{Int}(1,2) + KnotVector{Rational{Int}}(3) isa KnotVector{Rational{Int}}
         @test KnotVector{Int}(1,2)*0 == KnotVector()
         @test KnotVector{Int}(1,2)*0 isa KnotVector{Int}

--- a/test/test_Plots.jl
+++ b/test/test_Plots.jl
@@ -1,7 +1,7 @@
 @testset "Plots" begin
     @testset "B-spline space" begin
         p = 3
-        k = KnotVector(0:3)+p*KnotVector(0,3)
+        k = KnotVector(0:3)+p*KnotVector([0,3])
         P = BSplineSpace{p}(k)
         plot(P)
     end
@@ -23,7 +23,7 @@
     @testset "B-spline curve in 2d" begin
         a = [SVector(0, 0), SVector(1, 1), SVector(2, -1), SVector(3, 0), SVector(4, -2), SVector(5, 1)]
         p = 3
-        k = KnotVector(0:3)+p*KnotVector(0,3)
+        k = KnotVector(0:3)+p*KnotVector([0,3])
         P = BSplineSpace{p}(k)
         M = BSplineManifold(a, (P,))
         plot(M)
@@ -32,7 +32,7 @@
     @testset "B-spline curve in 3d" begin
         a = [SVector(0, 0, 2), SVector(1, 1, 1), SVector(2, -1, 4), SVector(3, 0, 0), SVector(4, -2, 0), SVector(5, 1, 2)]
         p = 3
-        k = KnotVector(0:3)+p*KnotVector(0,3)
+        k = KnotVector(0:3)+p*KnotVector([0,3])
         P = BSplineSpace{p}(k)
         M = BSplineManifold(a, (P,))
         plot(M)
@@ -42,7 +42,7 @@
         a = [SVector(0, 0), SVector(1, 1), SVector(2, -1), SVector(3, 0), SVector(4, -2), SVector(5, 1)]
         w = rand(6)
         p = 3
-        k = KnotVector(0:3)+p*KnotVector(0,3)
+        k = KnotVector(0:3)+p*KnotVector([0,3])
         P = BSplineSpace{p}(k)
         M = RationalBSplineManifold(a, w, (P,))
         plot(M)
@@ -52,7 +52,7 @@
         a = [SVector(0, 0, 2), SVector(1, 1, 1), SVector(2, -1, 4), SVector(3, 0, 0), SVector(4, -2, 0), SVector(5, 1, 2)]
         w = rand(6)
         p = 3
-        k = KnotVector(0:3)+p*KnotVector(0,3)
+        k = KnotVector(0:3)+p*KnotVector([0,3])
         P = BSplineSpace{p}(k)
         M = RationalBSplineManifold(a, w, (P,))
         plot(M)

--- a/test/test_RationalBSplineManifold.jl
+++ b/test/test_RationalBSplineManifold.jl
@@ -20,9 +20,9 @@
         p1 = 2
         p2 = 3
         p3 = 4
-        k1 = KnotVector(rand(30)) + (p1+1)*KnotVector(0,1)
-        k2 = KnotVector(rand(30)) + (p2+1)*KnotVector(0,1)
-        k3 = KnotVector(rand(30)) + (p3+1)*KnotVector(0,1)
+        k1 = KnotVector(rand(30)) + (p1+1)*KnotVector([0,1])
+        k2 = KnotVector(rand(30)) + (p2+1)*KnotVector([0,1])
+        k3 = KnotVector(rand(30)) + (p3+1)*KnotVector([0,1])
         P1 = BSplineSpace{p1}(k1)
         P2 = BSplineSpace{p2}(k2)
         P3 = BSplineSpace{p3}(k3)

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -2,8 +2,8 @@
     p1,p2,p3 = 3,2,4
 
     k1 = KnotVector(1:8)
-    k2 = KnotVector(1,3) + p2*KnotVector(1,3)
-    k3 = KnotVector(0,2) + p3*KnotVector(1,2)
+    k2 = KnotVector([1,3]) + p2*KnotVector([1,3])
+    k3 = KnotVector([0,2]) + p3*KnotVector([1,2])
 
     P1 = BSplineSpace{p1}(k1)
     P2 = BSplineSpace{p2}(k2)

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -9,8 +9,8 @@
     P2 = BSplineSpace{p2}(k2)
     P3 = BSplineSpace{p3}(k3)
 
-    P1′ = BSplineSpace{3}(k1+KnotVector(1.2,5.5,7.2,8.5))
-    P2′ = expandspace(P2, Val(1), KnotVector(1.8))
+    P1′ = BSplineSpace{3}(k1+KnotVector([1.2,5.5,7.2,8.5]))
+    P2′ = expandspace(P2, Val(1), KnotVector([1.8]))
     P3′ = BSplineSpace{4}(UniformKnotVector(-3:6))
 
     n1,n2,n3 = dim(P1),dim(P2),dim(P3)
@@ -27,8 +27,8 @@
     @testset "1dim" begin
         a = [Point(i, rand()) for i in 1:n1]
         p₊ = (Val(1),)
-        k₊ = (KnotVector(4.5),)
-        # k₊ = (KnotVector(4.5,4.95),)
+        k₊ = (KnotVector([4.5]),)
+        # k₊ = (KnotVector([4.5,4.95]),)
 
         @testset "BSplineManifold" begin
             w = ones(n1)
@@ -81,7 +81,7 @@
     @testset "2dim" begin
         a = [Point(i, rand()) for i in 1:n1, j in 1:n2]
         p₊ = (Val(1), Val(2))
-        k₊ = (KnotVector(4.5,4.7),KnotVector())
+        k₊ = (KnotVector([4.5,4.7]),KnotVector(Float64[]))
 
         @testset "BSplineManifold" begin
             w = ones(n1,n2)
@@ -138,7 +138,7 @@
     @testset "3dim" begin
         a = [Point(i, rand()) for i in 1:n1, j in 1:n2, k in 1:n3]
         p₊ = (Val(1), Val(2), Val(0))
-        k₊ = (KnotVector(4.4,4.7),KnotVector(),KnotVector(42))
+        k₊ = (KnotVector([4.4,4.7]),KnotVector(Float64[]),KnotVector([42]))
 
         @testset "BSplineManifold" begin
             w = ones(n1,n2,n3)

--- a/test/test_UniformKnotVector.jl
+++ b/test/test_UniformKnotVector.jl
@@ -69,7 +69,7 @@
         @test k1[1] == 1
         @test k2[end] == 3
         @test k4[2] == 3
-        @test k4[[1,2]] == KnotVector(2,3)
+        @test k4[[1,2]] == KnotVector([2,3])
         @test k3[2:4] == k4
         @test collect(k2) isa Vector{Int}
         @test [k2...] isa Vector{Int}


### PR DESCRIPTION
This PR adds deprecated messages to `KnotVector` and removes the methods from examples and tests. See #271.