### PR TITLE
Add methods to `Base.float` for `AbstractKnotVector`

### DIFF
--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -279,3 +279,7 @@ function countknots(k::AbstractKnotVector, t::Real)
     # for large case, this is faster
     return length(searchsorted(_vec(k), t, lt=<))
 end
+
+function Base.float(k::KnotVector{T}) where T
+    KnotVector(float(_vec(k)))
+end

--- a/src/_UniformKnotVector.jl
+++ b/src/_UniformKnotVector.jl
@@ -22,6 +22,10 @@ UniformKnotVector(k::UniformKnotVector) = k
 UniformKnotVector{T}(k::UniformKnotVector) where T = unsafe_uniformknotvector(T, k.vector)
 UniformKnotVector{T,R}(k::UniformKnotVector) where R<:AbstractRange{T} where T = unsafe_uniformknotvector(T, R(k.vector))
 
+function Base.float(k::UniformKnotVector)
+    UniformKnotVector(float(_vec(k)))
+end
+
 _vec(k::UniformKnotVector) = k.vector
 
 Base.getindex(k::UniformKnotVector, v::AbstractRange{<:Integer}) = UniformKnotVector(sort(k.vector[v]))

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -166,6 +166,20 @@
         @test string(KnotVector(Int[])) == "KnotVector(Int64[])"
     end
 
+    @testset "float" begin
+        k = KnotVector([1,2,3])
+        @test float(k) isa KnotVector{Float64}
+        @test k == float(k)
+
+        k = KnotVector{Float32}([1,2,3])
+        @test float(k) isa KnotVector{Float32}
+        @test k == float(k)
+
+        k = KnotVector{Rational{Int}}([1,2,3])
+        @test float(k) isa KnotVector{Float64}
+        @test k == float(k)
+    end
+
     @testset "other operators" begin
         k = KnotVector([1,2,2,3])
         @test countknots(k, 0.3) == 0

--- a/test/test_UniformKnotVector.jl
+++ b/test/test_UniformKnotVector.jl
@@ -123,6 +123,20 @@
         @test string(k3) == "UniformKnotVector(1:4)"
     end
 
+    @testset "float" begin
+        k = UniformKnotVector(1:3)
+        @test float(k) isa UniformKnotVector{Float64}
+        @test k == float(k)
+
+        k = UniformKnotVector(1f0:3f0)
+        @test float(k) isa UniformKnotVector{Float32}
+        @test k == float(k)
+
+        k = UniformKnotVector(1//1:3//1)
+        @test float(k) isa UniformKnotVector{Float64}
+        @test k == float(k)
+    end
+
     @testset "other operators" begin
         @test countknots(k2, 0.3) == 0
         @test countknots(k2, 1) == 1


### PR DESCRIPTION
This PR fixes https://github.com/hyrodium/BasicBSpline.jl/issues/208.