### PR TITLE
Fix precision of `changebasis`

### DIFF
--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -2,7 +2,7 @@
 # See https://hackmd.io/lpA0D0ySTQ6Hq1CdaaONxQ for more information.
 
 @doc raw"""
-Return a coefficient matrix A which satisfy
+Return a coefficient matrix ``A`` which satisfy
 ```math
 B_{(i,p,k)} = \sum_{j}A_{i,j}B_{(j,p',k')}
 ```
@@ -98,7 +98,7 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
 end
 
 @doc raw"""
-Return a coefficient matrix A which satisfy
+Return a coefficient matrix ``A`` which satisfy
 ```math
 B_{(i,p_1,k_1)} = \sum_{j}A_{i,j}B_{(j,p_2,k_2)}
 ```
@@ -171,7 +171,7 @@ function _derivatives_at_right(::BSplineSpace{0,T}) where {T}
 end
 
 @doc raw"""
-Return a coefficient matrix A which satisfy
+Return a coefficient matrix ``A`` which satisfy
 ```math
 B_{(i,p,k)} = \sum_{j}A_{i,j}B_{(j,p',k')}
 ```

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -87,8 +87,8 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
             A₊ = copy(Ãᵖ[ȷ])
             A₋ = copy(Ãᵖ[ȷ])
             for j in 1:Λ[ȷ]-2
-                A₊[:, j+1] = A₊[:, j] + Δ[:, j+r[1]]
-                A₋[:, Λ[ȷ]-j] = A₋[:, Λ[ȷ]-j+1] - Δ[:, Λ[ȷ]-j+r[1]]
+                A₊[:, j+1] .= A₊[:, j] .+ Δ[:, j+r[1]]
+                A₋[:, Λ[ȷ]-j] .= A₋[:, Λ[ȷ]-j+1] .- Δ[:, Λ[ȷ]-j+r[1]]
             end
             # Ãᵖ[ȷ] .= A₊
             # Ãᵖ[ȷ] .= A₋

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -90,7 +90,10 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
                 A₊[:, j+1] = A₊[:, j] + Δ[:, j+r[1]]
                 A₋[:, Λ[ȷ]-j] = A₋[:, Λ[ȷ]-j+1] - Δ[:, Λ[ȷ]-j+r[1]]
             end
-            Ãᵖ[ȷ] = (A₊ + A₋) / 2
+            # Ãᵖ[ȷ] .= A₊
+            # Ãᵖ[ȷ] .= A₋
+            # Ãᵖ[ȷ] .= (A₊ .+ A₋) ./ 2
+            Ãᵖ[ȷ] .= sqrt.(A₊ .* A₋)
         end
     end
     _Aᵖ = reduce(hcat, Ãᵖ) # n × n′ matrix


### PR DESCRIPTION
This PR fixes https://github.com/hyrodium/BasicBSpline.jl/issues/177#issuecomment-1451888603.

**Before this PR**
```julia
julia> using BasicBSpline

julia> p = 3
3

julia> P = BSplineSpace{p}(KnotVector([4,4,4,4,5,6,7,7,7,7]))
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([4, 4, 4, 4, 5, 6, 7, 7, 7, 7]))

julia> P′ = BSplineSpace{p}(KnotVector([4,4,4,4,4.5,5,6,7,7,7,7]))
BSplineSpace{3, Float64, KnotVector{Float64}}(KnotVector([4.0, 4.0, 4.0, 4.0, 4.5, 5.0, 6.0, 7.0, 7.0, 7.0, 7.0]))

julia> changebasis(P,P′)
6×7 Matrix{Float64}:
 1.0   0.5          0.0          0.0       0.0           0.0          0.0
 0.0   0.5          0.75         0.0       0.0           0.0          0.0
 0.0  -5.55112e-17  0.25         0.833333  5.55112e-17   5.55112e-17  0.0
 0.0   4.16334e-17  4.16334e-17  0.166667  1.0          -5.55112e-17  0.0
 0.0   0.0          0.0          0.0       0.0           1.0          0.0
 0.0   0.0          0.0          0.0       0.0           0.0          1.0
```

**After this PR**
```julia
julia> using BasicBSpline

julia> p = 3
3

julia> P = BSplineSpace{p}(KnotVector([4,4,4,4,5,6,7,7,7,7]))
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([4, 4, 4, 4, 5, 6, 7, 7, 7, 7]))

julia> P′ = BSplineSpace{p}(KnotVector([4,4,4,4,4.5,5,6,7,7,7,7]))
BSplineSpace{3, Float64, KnotVector{Float64}}(KnotVector([4.0, 4.0, 4.0, 4.0, 4.5, 5.0, 6.0, 7.0, 7.0, 7.0, 7.0]))

julia> changebasis(P,P′)
6×7 Matrix{Float64}:
 1.0   0.5  0.0   0.0       0.0   0.0  0.0
 0.0   0.5  0.75  0.0       0.0   0.0  0.0
 0.0  -0.0  0.25  0.833333  0.0   0.0  0.0
 0.0   0.0  0.0   0.166667  1.0  -0.0  0.0
 0.0   0.0  0.0   0.0       0.0   1.0  0.0
 0.0   0.0  0.0   0.0       0.0   0.0  1.0
```