### PR TITLE
Faster `changebasis`

### DIFF
--- a/src/BasicBSpline.jl
+++ b/src/BasicBSpline.jl
@@ -19,7 +19,8 @@ export bsplinebasisall, intervalindex
 # B-spline space
 export issqsubset, ⊑, ⊒, ⋢, ⋣, ⋤, ⋥, ≃
 export dim, exactdim
-export domain, changebasis
+export domain
+export changebasis, changebasis_R, changebasis_I
 export bsplinesupport, bsplinesupport_R, bsplinesupport_I
 export expandspace, expandspace_R, expandspace_I
 export isdegenerate, isdegenerate_R, isdegenerate_I

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -36,14 +36,14 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
     n = dim(P)
     n′ = dim(P′)
 
-    Aᵖ⁻¹ = _changebasis_R(_lower(P), _lower(P′))  # (n+1) × (n′+1) matrix
-    Aᵖ = zeros(U, n, n′)  # n × n′ matrix
-
     Z = _iszeros(_lower(P′))
     W = findall(Z)
     K′ = [k′[i+p′] - k′[i] for i in 1:n′+1]
     K = U[ifelse(k[i+p] ≠ k[i], U(1 / (k[i+p] - k[i])), zero(U)) for i in 1:n+1]
+
+    Aᵖ⁻¹ = _changebasis_R(_lower(P), _lower(P′))  # (n+1) × (n′+1) matrix
     Δ = (p / p′) * [K′[j] * (K[i] * Aᵖ⁻¹[i, j] - K[i+1] * Aᵖ⁻¹[i+1, j]) for i in 1:n, j in 1:n′+1]
+    Aᵖ = zeros(U, n, n′)  # n × n′ matrix
     Aᵖ[:, 1] = Δ[:, 1]
     Aᵖ[:, n′] = -Δ[:, n′+1]
 

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -99,18 +99,22 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
         elseif flags[i] == 3
             t = k′[i+1]
             for j in 1:n
-                Aᵖ[j,i] = bsplinebasis₊₀(P,j,t)
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
+                Aᵖ[j, i] = bsplinebasis₊₀(P,j,t)
             end
         elseif flags[i] == 4
             for j in 1:n
-                Aᵖ[j, 1] = (p / p′) * K′[1] * (K[j] * Aᵖ⁻¹[j, 1] - K[j+1] * Aᵖ⁻¹[j+1, 1])
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
+                Aᵖ[j, i] = (p / p′) * K′[1] * (K[j] * Aᵖ⁻¹[j, 1] - K[j+1] * Aᵖ⁻¹[j+1, 1])
             end
         elseif flags[i] == 5
             for j in 1:n
-                Aᵖ[j, n′] = -(p / p′) * K′[n′+1] * (K[j] * Aᵖ⁻¹[j, n′+1] - K[j+1] * Aᵖ⁻¹[j+1, n′+1])
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
+                Aᵖ[j, i] = -(p / p′) * K′[n′+1] * (K[j] * Aᵖ⁻¹[j, n′+1] - K[j+1] * Aᵖ⁻¹[j+1, n′+1])
             end
         elseif flags[i] == 6
             for j in 1:n
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
                 Aᵖ[j, i] = Aᵖ[j, i-1] + (p / p′) * K′[i] * (K[j] * Aᵖ⁻¹[j, i] - K[j+1] * Aᵖ⁻¹[j+1, i])
             end
         end
@@ -118,12 +122,13 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
     for i in n′:-1:1
         if flags[i] == 7
             for j in 1:n
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
                 Aᵖ[j, i] = Aᵖ[j, i+1] - (p / p′) * K′[i+1] * (K[j] * Aᵖ⁻¹[j, i+1] - K[j+1] * Aᵖ⁻¹[j+1, i+1])
             end
         end
     end
 
-    return Aᵖ .* U[bsplinesupport(P′,j) ⊆ bsplinesupport(P,i) for i in 1:n, j in 1:n′]
+    return Aᵖ
 end
 
 @doc raw"""

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -94,6 +94,7 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
         if flags[i] == 2
             t = k′[i+1]
             for j in 1:n
+                k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue
                 Aᵖ[j,i] = bsplinebasis₋₀(P,j,t)
             end
         elseif flags[i] == 3

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -120,7 +120,7 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
             end
         end
     end
-    for i in n′:-1:1
+    for i in reverse(1:n′)
         if flags[i] == 7
             for j in 1:n
                 k[j] ≤ k′[i] && k′[i+p′+1] ≤ k[j+p+1] || continue

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -10,7 +10,10 @@ B_{(i,p,k)} = \sum_{j}A_{i,j}B_{(j,p',k')}
 Assumption:
 * ``P ⊆ P^{\prime}``
 """
-function _changebasis_R end
+function changebasis_R(P::AbstractFunctionSpace, P′::AbstractFunctionSpace)
+    P ⊆ P′ || throw(DomainError((P,P′),"P ⊆ P′ should be hold."))
+    return _changebasis_R(P, P′)
+end
 
 function _changebasis_R(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T′}) where {p,T,p′,T′}
     _P = BSplineSpace{p,T,KnotVector{T}}(P)
@@ -19,7 +22,6 @@ function _changebasis_R(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T′}) whe
 end
 
 function _changebasis_R(P::BSplineSpace{0,T,KnotVector{T}}, P′::BSplineSpace{p′,T′,KnotVector{T′}}) where {p′,T,T′}
-    P ⊆ P′ || throw(DomainError((P,P′),"P ⊆ P′ should be hold."))
     U = StaticArrays.arithmetic_closure(promote_type(T,T′))
     n = dim(P)
     n′ = dim(P′)
@@ -29,7 +31,6 @@ function _changebasis_R(P::BSplineSpace{0,T,KnotVector{T}}, P′::BSplineSpace{p
 end
 
 function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p′,T′,KnotVector{T′}}) where {p,p′,T,T′}
-    P ⊆ P′ || throw(DomainError((P,P′),"P ⊆ P′ should be hold."))
     U = StaticArrays.arithmetic_closure(promote_type(T,T′))
     k = knotvector(P)
     k′ = knotvector(P′)
@@ -182,8 +183,12 @@ B_{(i,p,k)} = \sum_{j}A_{i,j}B_{(j,p',k')}
 Assumption:
 * ``P ⊑ P^{\prime}``
 """
-function _changebasis_I(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T′}) where {p,p′,T,T′}
+function changebasis_I(P::AbstractFunctionSpace, P′::AbstractFunctionSpace)
     P ⊑ P′ || throw(DomainError((P,P′),"P ⊑ P′ should be hold."))
+    return _changebasis_I(P, P′)
+end
+
+function _changebasis_I(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T′}) where {p,p′,T,T′}
     k = knotvector(P)
     k′ = knotvector(P′)
 
@@ -199,7 +204,6 @@ end
 
 ## Uniform B-spline space
 function _changebasis_R(P::BSplineSpace{p,T,<:UniformKnotVector{T}}, P′::BSplineSpace{p,T′,<:UniformKnotVector{T′}}) where {p,T,T′}
-    P ⊆ P′ || throw(DomainError((P,P′),"P ⊆ P′ should be hold."))
     k = knotvector(P)
     k′ = knotvector(P′)
     r = round(Int, step(k)/step(k′))
@@ -214,7 +218,6 @@ function _changebasis_R(P::BSplineSpace{p,T,<:UniformKnotVector{T}}, P′::BSpli
     return A
 end
 function _changebasis_I(P::BSplineSpace{p,T,<:UniformKnotVector{T}}, P′::BSplineSpace{p,T′,<:UniformKnotVector{T′}}) where {p,T,T′}
-    P ⊑ P′ || throw(DomainError((P,P′),"P ⊑ P′ should be hold."))
     k = knotvector(P)
     k′ = knotvector(P′)
     r = round(Int, step(k)/step(k′))
@@ -237,7 +240,6 @@ end
 
 ## BSplineDerivativeSpace
 function _changebasis_R(dP::BSplineDerivativeSpace{r,<:BSplineSpace{p}}, P′::BSplineSpace) where {r,p}
-    dP ⊆ P′ || throw(DomainError((P,P′),"dP ⊆ P′ should be hold."))
     k = knotvector(dP)
     n = dim(dP)
     A = Matrix(I(n))
@@ -255,12 +257,10 @@ function _changebasis_R(dP::BSplineDerivativeSpace{r,<:BSplineSpace{p}}, P′::B
     return A
 end
 function _changebasis_R(dP::BSplineDerivativeSpace, dP′::BSplineDerivativeSpace{0})
-    dP ⊆ dP′ || throw(DomainError((dP,dP′),"dP ⊆ dP′ should be hold."))
     P′ = bsplinespace(dP′)
     return _changebasis_R(dP, P′)
 end
 function _changebasis_R(dP::BSplineDerivativeSpace{r}, dP′::BSplineDerivativeSpace{r′}) where {r,r′}
-    dP ⊆ dP′ || throw(DomainError((dP,dP′),"dP ⊆ dP′ should be hold."))
     if r > r′
         P = bsplinespace(dP)
         P′ = bsplinespace(dP′)
@@ -280,5 +280,5 @@ end
 function changebasis(P::AbstractFunctionSpace, P′::AbstractFunctionSpace)
     P ⊆ P′ && return _changebasis_R(P, P′)
     P ⊑ P′ && return _changebasis_I(P, P′)
-    throw(DomainError((P, P′),"𝒫[p,k] ⊆ 𝒫[p′,k′] or 𝒫[p,k] ⊑ 𝒫[p′,k′] must hold."))
+    throw(DomainError((P, P′),"P ⊆ P′ or P ⊑ P′ must hold."))
 end

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -33,7 +33,7 @@
         P1 = BSplineSpace{1}(KnotVector([1, 3, 5, 8]))
         P2 = BSplineSpace{1}(KnotVector([1, 3, 5, 6, 8, 9]))
         P3 = BSplineSpace{2}(KnotVector([1, 1, 3, 3, 5, 5, 8, 8]))
-        P4 = BSplineSpace{2}(KnotVector([1, 3, 4, 4, 4, 4, 5, 8]))
+        P4 = BSplineSpace{1}(KnotVector([1, 3, 4, 4, 4, 4, 5, 8]))
 
         test_changebasis_R(P1, P2)
         test_changebasis_R(P1, P3)

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -19,9 +19,22 @@
         P1 = BSplineSpace{1}(KnotVector([1, 3, 5, 8]))
         P2 = BSplineSpace{1}(KnotVector([1, 3, 5, 6, 8, 9]))
         P3 = BSplineSpace{2}(KnotVector([1, 1, 3, 3, 5, 5, 8, 8]))
+        P4 = BSplineSpace{2}(KnotVector([1, 3, 4, 4, 4, 4, 5, 8]))
+
         test_changebasis_R(P1, P2)
         test_changebasis_R(P1, P3)
+        test_changebasis_R(P1, P4)
+
         @test P2 ⊈ P3
+
+        @test isnondegenerate(P1)
+        @test isnondegenerate(P2)
+        @test isnondegenerate(P3)
+        @test isdegenerate(P4)
+        @test changebasis_R(P1, P1) == I
+        @test changebasis_R(P2, P2) == I
+        @test changebasis_R(P3, P3) == I
+        @test changebasis_R(P4, P4) ≠ I
     end
 
     @testset "sqsubseteq (I)" begin

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -1,5 +1,5 @@
 @testset "ChangeBasis" begin
-    ε = 1e-14
+    ε = 1e-13
     function test_changebasis_R(P,P′)
         @test P ⊆ P′
         A = @inferred changebasis(P,P′)
@@ -11,7 +11,7 @@
         t_max = maximum(knotvector(P)+knotvector(P′))
         ts = range(t_min,t_max,length=20)
         for t in ts
-            @test norm(bsplinebasis.(P,1:n,t) - A*bsplinebasis.(P′,1:n′,t), Inf) < 1e-14
+            @test norm(bsplinebasis.(P,1:n,t) - A*bsplinebasis.(P′,1:n′,t), Inf) < ε
         end
     end
 
@@ -25,7 +25,7 @@
         d = domain(P)
         ts = range(extrema(d)..., length=20)
         for t in ts
-            @test norm(bsplinebasis.(P,1:n,t) - A*bsplinebasis.(P′,1:n′,t), Inf) < 1e-14
+            @test norm(bsplinebasis.(P,1:n,t) - A*bsplinebasis.(P′,1:n′,t), Inf) < ε
         end
     end
 
@@ -87,7 +87,7 @@
             n = dim(P1)
             for _ in 1:100
                 t = rand(D)
-                @test norm(bsplinebasis.(P1,1:n,t) - A*bsplinebasis.(P2,1:n,t), Inf) < 1e-14
+                @test norm(bsplinebasis.(P1,1:n,t) - A*bsplinebasis.(P2,1:n,t), Inf) < ε
             end
         end
     end


### PR DESCRIPTION
**Before this PR**
```julia
julia> using BasicBSpline, BenchmarkTools

julia> P1 = BSplineSpace{1}(KnotVector([1, 3, 5, 8]))
BSplineSpace{1, Int64, KnotVector{Int64}}(KnotVector([1, 3, 5, 8]))

julia> P2 = BSplineSpace{1}(KnotVector([1, 3, 5, 6, 8, 9]))
BSplineSpace{1, Int64, KnotVector{Int64}}(KnotVector([1, 3, 5, 6, 8, 9]))

julia> @benchmark changebasis(P1, P2)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.898 μs … 350.734 μs  ┊ GC (min … max):  0.00% … 99.22%
 Time  (median):     2.059 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   2.501 μs ±  10.480 μs  ┊ GC (mean ± σ):  13.18% ±  3.12%

   ▄▆▇███▇▆▅▃▃▁▁▂▂▃▂▃▂▂▂▁▁▁▁                                  ▂
  ███████████████████████████████▇███▇███▇████████▇▆▇▆▇▇▆▆▆▆▄ █
  1.9 μs       Histogram: log(frequency) by time      3.47 μs <

 Memory estimate: 4.59 KiB, allocs estimate: 51.
```

**After this PR**
```julia
julia> using BasicBSpline, BenchmarkTools

julia> P1 = BSplineSpace{1}(KnotVector([1, 3, 5, 8]))
BSplineSpace{1, Int64, KnotVector{Int64}}(KnotVector([1, 3, 5, 8]))

julia> P2 = BSplineSpace{1}(KnotVector([1, 3, 5, 6, 8, 9]))
BSplineSpace{1, Int64, KnotVector{Int64}}(KnotVector([1, 3, 5, 6, 8, 9]))

julia> @benchmark changebasis(P1, P2)
BenchmarkTools.Trial: 10000 samples with 78 evaluations.
 Range (min … max):  829.256 ns … 39.370 μs  ┊ GC (min … max):  0.00% … 96.59%
 Time  (median):     865.090 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   993.385 ns ±  1.955 μs  ┊ GC (mean ± σ):  10.73% ±  5.31%

   ▄▇██▇▆▄▃▂▁▁                                                 ▂
  ███████████████▇▇▇▇▇▇▇███▇█▇▆▆▆▆▄▄▄▃▅▅▅▆▇▆▅▆▇▇▇▆▇▇▇▆▆▅▄▆▅▆▆▆ █
  829 ns        Histogram: log(frequency) by time      1.29 μs <

 Memory estimate: 1.81 KiB, allocs estimate: 18.
```