### PR TITLE
Add `copy(::SubKnotVector)`

### DIFF
--- a/src/_KnotVector.jl
+++ b/src/_KnotVector.jl
@@ -103,6 +103,7 @@ SubKnotVector{T,S}(k::SubKnotVector{T,S}) where {T,S} = k
 Base.copy(k::EmptyKnotVector{T}) where T = k
 Base.copy(k::KnotVector{T}) where T = unsafe_knotvector(T,copy(_vec(k)))
 Base.copy(k::UniformKnotVector{T}) where T = unsafe_uniformknotvector(T,copy(_vec(k)))
+Base.copy(k::SubKnotVector{T}) where T = unsafe_knotvector(T,copy(_vec(k)))
 
 KnotVector(k::KnotVector) = k
 KnotVector(k::AbstractKnotVector{T}) where T = unsafe_knotvector(T,_vec(k))

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -55,10 +55,12 @@
     end
 
     @testset "SubKnotVector and view" begin
-        k = KnotVector(1:8)
-        view(k, 1:3) isa SubKnotVector
-        k = UniformKnotVector(1:8)
-        view(k, 1:3) isa UniformKnotVector
+        k1 = KnotVector(1:8)
+        k2 = UniformKnotVector(1:8)
+        @test view(k1, 1:3) isa SubKnotVector
+        @test view(k2, 1:3) isa UniformKnotVector
+        @test copy(view(k1, 1:3)) isa KnotVector
+        @test copy(view(k1, 1:3)) == view(k1, 1:3) == KnotVector(1:3) == k1[1:3]
     end
 
     @testset "zeros" begin

--- a/test/test_KnotVector.jl
+++ b/test/test_KnotVector.jl
@@ -1,8 +1,7 @@
 @testset "KnotVector" begin
-    k1 = KnotVector([1,2,3])
-    k2 = KnotVector([1,2,2,3])
-    k3 = KnotVector([2,4,5])
     @testset "constructor" begin
+        k1 = KnotVector([1,2,3])
+        k2 = KnotVector([1,2,2,3])
         @test k1 isa KnotVector{Int64}
         @test k1 == KnotVector(1:3)::KnotVector{Int}
         @test k1 == KnotVector([1,3,2])::KnotVector{Int64}
@@ -64,6 +63,8 @@
     end
 
     @testset "zeros" begin
+        k1 = KnotVector([1,2,3])
+
         @test KnotVector(Float64[]) == zero(KnotVector)
         @test KnotVector(Float64[]) == 0*k1 == k1*0 == zero(k1)
         @test KnotVector(Float64[]) == EmptyKnotVector()
@@ -98,6 +99,9 @@
     end
 
     @testset "iterator" begin
+        k1 = KnotVector([1,2,3])
+        k2 = KnotVector([1,2,2,3])
+        k3 = KnotVector([2,4,5])
         for t in k1
             @test t in k2
         end
@@ -110,6 +114,10 @@
     end
 
     @testset "addition, multiply" begin
+        k1 = KnotVector([1,2,3])
+        k2 = KnotVector([1,2,2,3])
+        k3 = KnotVector([2,4,5])
+
         @test KnotVector([-1,2,3]) + 2 * KnotVector([2,5]) == KnotVector([-1,2,2,2,3,5,5])
         @test KnotVector([-1,2,3]) + KnotVector([2,5]) * 2 == KnotVector([-1,2,2,2,3,5,5])
         @test k1 + k3 == KnotVector([1,2,2,3,4,5])
@@ -151,6 +159,9 @@
     end
 
     @testset "unique" begin
+        k1 = KnotVector([1,2,3])
+        k2 = KnotVector([1,2,2,3])
+
         @test unique(k1) == k1
         @test unique(k2) == k1
         @test unique(EmptyKnotVector()) === EmptyKnotVector()


### PR DESCRIPTION
**Before this PR**
```julia
julia> using BasicBSpline

julia> k = KnotVector(1:8)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8])

julia> view(k, 1:3)
SubKnotVector([1, 2, 3])

julia> copy(view(k, 1:3))
ERROR: MethodError: no method matching copy(::SubKnotVector{Int64, SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}})

Closest candidates are:
  copy(::Base.ReshapedArray{<:Any, 2, <:SparseArrays.AbstractSparseMatrixCSC})
   @ SparseArrays ~/.julia/juliaup/julia-1.9.3+0.x64.linux.gnu/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:508
  copy(::Base.IdSet)
   @ Base idset.jl:16
  copy(::LinearAlgebra.Tridiagonal)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.3+0.x64.linux.gnu/share/julia/stdlib/v1.9/LinearAlgebra/src/tridiag.jl:613
  ...
```

**After this PR**
```julia
julia> using BasicBSpline

julia> k = KnotVector(1:8)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8])

julia> view(k, 1:3)
SubKnotVector([1, 2, 3])

julia> copy(view(k, 1:3))
KnotVector([1, 2, 3])
```
