### PR TITLE
More performance

### DIFF
--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -177,28 +177,21 @@ Check inclusive relationship between B-spline spaces.
 ```
 """
 function issqsubset(P::BSplineSpace{p}, P′::BSplineSpace{p′}) where {p, p′}
-    # TODO: fix https://github.com/hyrodium/BasicBSpline.jl/issues/329
+    p₊ = p′ - p
+    p₊ < 0 && return false
+
     k = knotvector(P)
     k′ = knotvector(P′)
+    !(k[1+p] == k′[1+p′] < k′[end-p′] == k[end-p]) && return false
+
     l = length(k)
     l′ = length(k′)
-    p₊ = p′ - p
-
-    if p₊ < 0
-        return false
-    elseif domain(P) ≠ domain(P′)
-        # The domains must be equal for P ⊑ P′.
-        return false
-    elseif !(k′[1+p′] < k′[end-p′])
-        # The width(domain(P′)) must be non-zero for P ⊑ P′.
-        # There may be some edge-case like P′ ⊑ P′, but we don't need `true` for that situation.
-        return false
-    end
-
     inner_knotvector = view(k, p+2:l-p-1)
     inner_knotvector′ = view(k′, p′+2:l′-p′-1)
 
-    return inner_knotvector + p₊ * unique(inner_knotvector) ⊆ inner_knotvector′
+    _P = BSplineSpace{p}(inner_knotvector)
+    _P′ = BSplineSpace{p′}(inner_knotvector′)
+    return _P ⊆ _P′
 end
 
 const ⊑ = issqsubset

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -404,11 +404,10 @@ function __changebasis_I_old(P1::BSplineSpace{p,T}, P2::BSplineSpace{p′,T′})
     return _A
 end
 
-function _find_j_range_I(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_range) where {p, p′}
-    # TODO: avoid `_changebasis_I_old`
+function _find_j_range_I(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_range, Aᵖ_old) where {p, p′}
+    # TODO: remove `Aᵖ_old` argument
     # TODO: fix performance https://github.com/hyrodium/BasicBSpline.jl/pull/323#issuecomment-1723216566
     # TODO: remove threshold such as 1e-14
-    Aᵖ_old = __changebasis_I_old(P,P′)
     j_begin = findfirst(e->abs(e)>1e-14, Aᵖ_old[i, :])
     j_end = findlast(e->abs(e)>1e-14, Aᵖ_old[i, :])
     return j_begin:j_end
@@ -466,6 +465,7 @@ function _changebasis_I(P::BSplineSpace{p,T,<:AbstractKnotVector{T}}, P′::BSpl
     # R = fill(-1, n_nonzero)
     s = 1
     j_range = 1:1  # j_begin:j_end
+    Aᵖ_old = __changebasis_I_old(P, P′)
     for i in 1:n
         # Skip for degenerated basis
         isdegenerate_I(P,i) && continue
@@ -545,7 +545,7 @@ function _changebasis_I(P::BSplineSpace{p,T,<:AbstractKnotVector{T}}, P′::BSpl
         =#
 
         # Precalculate the range of j
-        j_range = _find_j_range_I(P, P′, i, j_range)
+        j_range = _find_j_range_I(P, P′, i, j_range, Aᵖ_old)
         j_begin, j_end = extrema(j_range)
 
         # Rule-0: outside of j_range

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -52,11 +52,12 @@ function _changebasis_R(P::BSplineSpace{0,T,KnotVector{T}}, P′::BSplineSpace{p
     return A⁰
 end
 
-function _find_j_range_R(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_begin, j_end) where {p, p′}
+function _find_j_range_R(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_range) where {p, p′}
     k = knotvector(P)
     k′ = knotvector(P′)
     n′ = dim(P′)
     Pi = BSplineSpace{p}(view(k, i:i+p+1))
+    j_begin, j_end = extrema(j_range)
 
     # Find `j_end`. This is the same as:
     # j_end::Int = findnext(j->Pi ⊆ BSplineSpace{p′}(view(k′, j_begin:j+p′+1)), 1:n′, j_end)
@@ -145,8 +146,7 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
     J = Vector{Int32}(undef, n_nonzero)
     V = Vector{U}(undef, n_nonzero)
     s = 1
-    j_begin = 1
-    j_end = 1
+    j_range = 1:1  # j_begin:j_end
     for i in 1:n
         # Skip for degenerated basis
         isdegenerate_R(P,i) && continue
@@ -205,7 +205,7 @@ function _changebasis_R(P::BSplineSpace{p,T,KnotVector{T}}, P′::BSplineSpace{p
         =#
 
         # Precalculate the range of j
-        j_range = _find_j_range_R(P, P′, i, j_begin, j_end)
+        j_range = _find_j_range_R(P, P′, i, j_range)
         j_begin, j_end = extrema(j_range)
 
         # Rule-0: outside of j_range
@@ -404,7 +404,7 @@ function __changebasis_I_old(P1::BSplineSpace{p,T}, P2::BSplineSpace{p′,T′})
     return _A
 end
 
-function _find_j_range_I(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_begin, j_end) where {p, p′}
+function _find_j_range_I(P::BSplineSpace{p}, P′::BSplineSpace{p′}, i, j_range) where {p, p′}
     # TODO: avoid `_changebasis_I_old`
     # TODO: fix performance https://github.com/hyrodium/BasicBSpline.jl/pull/323#issuecomment-1723216566
     # TODO: remove threshold such as 1e-14
@@ -465,8 +465,7 @@ function _changebasis_I(P::BSplineSpace{p,T,<:AbstractKnotVector{T}}, P′::BSpl
     V = Vector{U}(undef, n_nonzero)
     # R = fill(-1, n_nonzero)
     s = 1
-    j_begin = 1
-    j_end = 1
+    j_range = 1:1  # j_begin:j_end
     for i in 1:n
         # Skip for degenerated basis
         isdegenerate_I(P,i) && continue
@@ -546,7 +545,7 @@ function _changebasis_I(P::BSplineSpace{p,T,<:AbstractKnotVector{T}}, P′::BSpl
         =#
 
         # Precalculate the range of j
-        j_range = _find_j_range_I(P, P′, i, j_begin, j_end)
+        j_range = _find_j_range_I(P, P′, i, j_range)
         j_begin, j_end = extrema(j_range)
 
         # Rule-0: outside of j_range

--- a/src/_ChangeBasis.jl
+++ b/src/_ChangeBasis.jl
@@ -395,11 +395,11 @@ function _changebasis_I_old(P::BSplineSpace{p,T}, P′::BSplineSpace{p′,T′})
     return A
 end
 
-function __changebasis_I_old(P1, P2)
+function __changebasis_I_old(P1::BSplineSpace{p,T}, P2::BSplineSpace{p′,T′}) where {p,p′,T,T′}
+    U = StaticArrays.arithmetic_closure(promote_type(T, T′))
     _P1 = _nondegeneratize_I(P1)
     _P2 = _nondegeneratize_I(P2)
-    A = _changebasis_I_old(P1,P2)
-    _A = zero(A)
+    _A = sparse(Int32[], Int32[], U[], dim(P1), dim(P2))
     _A[isnondegenerate_I.(P1,1:dim(P1)), isnondegenerate_I.(P2,1:dim(P2))] = _changebasis_I_old(_P1,_P2)
     return _A
 end


### PR DESCRIPTION
This PR fixes https://github.com/hyrodium/BasicBSpline.jl/issues/333

**Before this PR**

```julia
julia> using BasicBSpline, BenchmarkTools

julia> Pd1 = BSplineSpace{2}(knotvector" 21 3")
BSplineSpace{2, Int64, KnotVector{Int64}}(KnotVector([2, 2, 3, 5, 5, 5]))

julia> Pd2 = BSplineSpace{3}(knotvector"212 4")
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 3, 3, 5, 5, 5, 5]))

julia> @benchmark BasicBSpline.changebasis_I(Pd1, Pd2)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  52.760 μs …   3.479 ms  ┊ GC (min … max):  0.00% … 95.56%
 Time  (median):     57.709 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   65.825 μs ± 149.739 μs  ┊ GC (mean ± σ):  10.40% ±  4.48%

    ▁▃▅▆▇████▇▆▅▄▃▂▂▂▁▁▁▁▁▁ ▁                                  ▃
  ▅▆█████████████████████████▇██▇▇▇▇▅▆▆▆▆▅▆▄▅▄▇▇▇▇▇▅▆▇▄▆▅▆▅▆▆▆ █
  52.8 μs       Histogram: log(frequency) by time      84.5 μs <

 Memory estimate: 98.53 KiB, allocs estimate: 1285.
```

**After this PR**

```julia
julia> using BasicBSpline, BenchmarkTools

julia> Pd1 = BSplineSpace{2}(knotvector" 21 3")
BSplineSpace{2, Int64, KnotVector{Int64}}(KnotVector([2, 2, 3, 5, 5, 5]))

julia> Pd2 = BSplineSpace{3}(knotvector"212 4")
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 3, 3, 5, 5, 5, 5]))

julia> @benchmark BasicBSpline.changebasis_I(Pd1, Pd2)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  11.662 μs …  3.282 ms  ┊ GC (min … max): 0.00% … 97.70%
 Time  (median):     12.975 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.312 μs ± 64.766 μs  ┊ GC (mean ± σ):  8.26% ±  1.94%

     ▇██▃▁                                                     
  ▂▄██████▅▄▃▂▂▃▃▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  11.7 μs         Histogram: frequency by time        23.8 μs <

 Memory estimate: 20.44 KiB, allocs estimate: 285.
```