### PR TITLE
Update tests for `changebasis`

### DIFF
--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -258,13 +258,11 @@ for (f, fnon) in ((:isdegenerate_R, :isnondegenerate_R), (:isdegenerate_I, :isno
         end
         return false
     end
-    @eval $fnon(P::BSplineSpace, i::Int) = !$f(P, i)
-    @eval $fnon(P::BSplineSpace) = !$f(P)
+    @eval $fnon(P, i::Integer) = !$f(P, i)
+    @eval $fnon(P) = !$f(P)
 end
-isdegenerate(P::BSplineSpace, i::Integer) = isdegenerate_R(P,i)
-isdegenerate(P::BSplineSpace) = isdegenerate_R(P)
-isnondegenerate(P::BSplineSpace, i::Integer) = isnondegenerate_R(P, i)
-isnondegenerate(P::BSplineSpace) = isnondegenerate_R(P)
+const isdegenerate = isdegenerate_R
+const isnondegenerate = isnondegenerate_R
 
 function _nondegeneratize_R(P::BSplineSpace{p}) where p
     k = copy(KnotVector(knotvector(P)))

--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -252,7 +252,7 @@ true
 isdegenerate(P::BSplineSpace)
 
 for (f, fnon) in ((:isdegenerate_R, :isnondegenerate_R), (:isdegenerate_I, :isnondegenerate_I))
-    @eval function $f(P::BSplineSpace)
+    @eval function $f(P::AbstractFunctionSpace)
         for i in 1:dim(P)
             $f(P,i) && return true
         end

--- a/src/_DerivativeSpace.jl
+++ b/src/_DerivativeSpace.jl
@@ -63,6 +63,14 @@ _lower_I(dP::BSplineDerivativeSpace{r}) where r = BSplineDerivativeSpace{r-1}(_l
 _iszeros_R(P::BSplineDerivativeSpace) = _iszeros_R(bsplinespace(P))
 _iszeros_I(P::BSplineDerivativeSpace) = _iszeros_I(bsplinespace(P))
 
+function isdegenerate_R(dP::BSplineDerivativeSpace, i::Integer)
+    return isdegenerate_R(bsplinespace(dP), i)
+end
+
+function isdegenerate_I(dP::BSplineDerivativeSpace, i::Integer)
+    return isdegenerate_I(bsplinespace(dP), i)
+end
+
 @doc raw"""
     derivative(::BSplineDerivativeSpace{r}) -> BSplineDerivativeSpace{r+1}
     derivative(::BSplineSpace) -> BSplineDerivativeSpace{1}

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -15,12 +15,12 @@
         @test size(A) == (n,n′)
         # Elements must not be stored for degenerate row/col
         for j in 1:n′
-            if isnondegenerate_R(P′, j)
+            if isdegenerate_R(P′, j)
                 @test !any(Base.isstored.(Ref(A), 1:n, j))
             end
         end
         for i in 1:n
-            if isnondegenerate_R(P, i)
+            if isdegenerate_R(P, i)
                 @test !any(Base.isstored.(Ref(A), i, 1:n′))
             end
         end

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -147,6 +147,23 @@
         test_changebasis_I(Q3, Q4)
     end
 
+    @testset "different changebasis_R and changebasis_I" begin
+        P1 = BSplineSpace{3}(knotvector"1111 132")
+        P2 = BSplineSpace{3}(knotvector"11121132")
+        @test isdegenerate_I(P1)
+        @test isdegenerate_I(P2)
+        @test isnondegenerate_R(P1)
+        @test isnondegenerate_R(P2)
+        @test P1 ⊆ P2
+        @test P1 ⊑ P2
+
+        test_changebasis_I(P1, P2)
+        test_changebasis_R(P1, P2)
+        A_R = changebasis_R(P1, P2)
+        A_I = changebasis_I(P1, P2)
+        @test A_R ≠ A_I
+    end
+
     @testset "changebasis_sim" begin
         for p in 1:3, L in 1:8
             k1 = UniformKnotVector(1:L+2p+1)

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -79,7 +79,7 @@
         A13 = changebasis(P1, P3)
         A36 = changebasis(P3, P6)
         A16 = changebasis(P1, P6)
-        A16 ≈ A13 * A36
+        @test A16 ≈ A13 * A36
 
         test_changebasis_R(P3, P6)
         test_changebasis_R(P6, P7)
@@ -87,7 +87,7 @@
         A36 = changebasis(P3, P6)
         A67 = changebasis(P6, P7)
         A37 = changebasis(P3, P7)
-        A37 ≈ A36 * A67
+        @test A37 ≈ A36 * A67
 
         @test P2 ⊈ P3
 

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -123,13 +123,14 @@
         _P8 = BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector(-[1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 7, 7]))
         test_changebasis_I(_P7, _P8)
 
+        # (2,2)-element is stored, but it is zero.
         Q1 = BSplineSpace{1, Int64, KnotVector{Int64}}(KnotVector([2, 2, 4, 4, 6, 6]))
         Q2 = BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 2, 3, 4, 4, 4, 4, 5, 5, 6, 6, 6, 6, 7]))
         test_changebasis_I(Q1, Q2; check_zero=false)
 
         Q3 = BSplineSpace{4, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 7]))
         Q4 = BSplineSpace{5, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 1, 1, 2, 3, 3, 3, 3, 4, 4, 4, 5, 6]))
-        test_changebasis_I(Q3, Q4; check_zero=false)
+        test_changebasis_I(Q3, Q4)
     end
 
     @testset "changebasis_sim" begin

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -15,10 +15,14 @@
         @test size(A) == (n,n′)
         # Elements must not be stored for degenerate row/col
         for j in 1:n′
-            @test any(Base.isstored.(Ref(A), 1:n, j)) == isnondegenerate_R(P′, j)
+            if isnondegenerate_R(P′, j)
+                @test !any(Base.isstored.(Ref(A), 1:n, j))
+            end
         end
         for i in 1:n
-            @test any(Base.isstored.(Ref(A), i, 1:n′)) == isnondegenerate_R(P, i)
+            if isnondegenerate_R(P, i)
+                @test !any(Base.isstored.(Ref(A), i, 1:n′))
+            end
         end
         # B_{(i,p,k)} = ∑ⱼ A_{i,j} B_{(j,p′,k′)}
         ts = range(extrema(knotvector(P)+knotvector(P′))..., length=20)

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -1,7 +1,7 @@
 @testset "ChangeBasis" begin
     ε = 1e-13
     function test_changebasis_R(P,P′)
-        # The test case must hold `P ⊆ P′`
+        # The test case must hold P ⊆ P′
         @test P ⊆ P′
         # Test type stability
         A = @inferred changebasis_R(P,P′)
@@ -9,7 +9,7 @@
         @test A isa SparseMatrixCSC
         # Zeros must not be stored
         @test !any(iszero.(A.nzval))
-        # Test the size of `A`
+        # Test the size of A
         n = dim(P)
         n′ = dim(P′)
         @test size(A) == (n,n′)

--- a/test/test_ChangeBasis.jl
+++ b/test/test_ChangeBasis.jl
@@ -15,10 +15,10 @@
         @test size(A) == (n,n′)
         # Elements must not be stored for degenerate row/col
         for j in 1:n′
-            @test any(Base.isstored.(Ref(A), 1:n, j)) == isnondegenerate_R(P2, j)
+            @test any(Base.isstored.(Ref(A), 1:n, j)) == isnondegenerate_R(P′, j)
         end
         for i in 1:n
-            @test any(Base.isstored.(Ref(A), i, 1:n′)) == isnondegenerate_R(P1, i)
+            @test any(Base.isstored.(Ref(A), i, 1:n′)) == isnondegenerate_R(P, i)
         end
         # B_{(i,p,k)} = ∑ⱼ A_{i,j} B_{(j,p′,k′)}
         ts = range(extrema(knotvector(P)+knotvector(P′))..., length=20)

--- a/test/test_Derivative.jl
+++ b/test/test_Derivative.jl
@@ -33,6 +33,25 @@
         @test_throws MethodError convert(BSplineDerivativeSpace{2},dP2)
     end
 
+    @testset "degenerate" begin
+        P1 = BSplineSpace{2}(KnotVector(1:8))
+        P2 = BSplineSpace{2}(knotvector"111111151111")
+        dP1 = BSplineDerivativeSpace{1}(P1)
+        dP2 = BSplineDerivativeSpace{1}(P2)
+        @test isdegenerate_R(P1) == isdegenerate_R(dP1)
+        @test isdegenerate_R(P2) == isdegenerate_R(dP2)
+        @test isdegenerate_I(P1) == isdegenerate_I(dP1)
+        @test isdegenerate_I(P2) == isdegenerate_I(dP2)
+        for i in 1:dim(P1)
+            @test isdegenerate_R(P1, i) == isdegenerate_R(dP1, i)
+            @test isdegenerate_I(P1, i) == isdegenerate_I(dP1, i)
+        end
+        for i in 1:dim(P2)
+            @test isdegenerate_R(P2, i) == isdegenerate_R(dP2, i)
+            @test isdegenerate_I(P2, i) == isdegenerate_I(dP2, i)
+        end
+    end
+
     # Not sure why this @testset doesn't work fine.
     # @testset "$(p)-th degree basis" for p in 0:p_max
     for p in 0:p_max


### PR DESCRIPTION
This PR fixes https://github.com/hyrodium/BasicBSpline.jl/issues/346.

**Before this PR**
```julia
julia> using BasicBSpline

julia> P = BSplineSpace{4, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 7]))
BSplineSpace{4, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 7]))

julia> P′ = BSplineSpace{5, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 6]))
BSplineSpace{5, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 6]))

julia> changebasis_I(P, P′)
6×10 SparseArrays.SparseMatrixCSC{Float64, Int32} with 27 stored entries:
   ⋅    2.8   0.4    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅ 
   ⋅   -4.4   2.0   0.8   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅ 
  2.8   2.8  -1.6   0.4  0.8  0.45  0.05  0.05  0.05  0.05
 -0.2  -0.2   0.2  -0.2  0.2  0.5   0.5   0.5   0.5   0.5
   ⋅     ⋅     ⋅     ⋅    ⋅   0.05  0.45   ⋅     ⋅     ⋅ 
   ⋅     ⋅     ⋅     ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅ 
```

**After this PR**
```julia
julia> using BasicBSpline

julia> P = BSplineSpace{4, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 7]))
BSplineSpace{4, Int64, KnotVector{Int64}}(KnotVector([1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 7]))

julia> P′ = BSplineSpace{5, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 6]))
BSplineSpace{5, Int64, KnotVector{Int64}}(KnotVector([1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 6]))

julia> changebasis_I(P, P′)
6×10 SparseMatrixCSC{Float64, Int32} with 19 stored entries:
  ⋅    2.8   0.4    ⋅    ⋅    ⋅     ⋅     ⋅    ⋅    ⋅ 
  ⋅   -4.4   2.0   0.8   ⋅    ⋅     ⋅     ⋅    ⋅    ⋅ 
  ⋅    2.8  -1.6   0.4  0.8  0.45  0.05   ⋅    ⋅    ⋅ 
  ⋅   -0.2   0.2  -0.2  0.2  0.5   0.5    ⋅    ⋅    ⋅ 
  ⋅     ⋅     ⋅     ⋅    ⋅   0.05  0.45   ⋅    ⋅    ⋅ 
  ⋅     ⋅     ⋅     ⋅    ⋅    ⋅     ⋅     ⋅    ⋅    ⋅
```
