### PR TITLE
Fix `expandspace_I`

### DIFF
--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -471,8 +471,13 @@ function expandspace_I(P::BSplineSpace{p,T}, ::Val{p₊}, k₊::AbstractKnotVect
     k = knotvector(P)
     I = domain(P)
     l = length(k)
-    k[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
-    k[l] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    l₊ = length(k₊)
+    if l₊ ≥ 1
+        k₊[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    end
+    if l₊ ≥ 2
+        k₊[end] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    end
     k̂ = unique(view(k, 1+p:l-p))
     p′ = p + p₊
     k′ = k + p₊*k̂ + k₊
@@ -483,9 +488,13 @@ end
 function expandspace_I(P::BSplineSpace{p,T}, k₊::AbstractKnotVector=EmptyKnotVector{T}()) where {p,T}
     k = knotvector(P)
     I = domain(P)
-    l = length(k)
-    k[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
-    k[l] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    l₊ = length(k₊)
+    if l₊ ≥ 1
+        k₊[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    end
+    if l₊ ≥ 2
+        k₊[end] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    end
     k′ = k + k₊
     P′ = BSplineSpace{p}(k′)
     return P′

--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -473,10 +473,10 @@ function expandspace_I(P::BSplineSpace{p,T}, ::Val{p₊}, k₊::AbstractKnotVect
     l = length(k)
     l₊ = length(k₊)
     if l₊ ≥ 1
-        k₊[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+        k₊[1] ∉ I && throw(DomainError(k₊, "input knot vector is out of domain."))
     end
     if l₊ ≥ 2
-        k₊[end] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+        k₊[end] ∉ I && throw(DomainError(k₊, "input knot vector is out of domain."))
     end
     k̂ = unique(view(k, 1+p:l-p))
     p′ = p + p₊
@@ -490,10 +490,10 @@ function expandspace_I(P::BSplineSpace{p,T}, k₊::AbstractKnotVector=EmptyKnotV
     I = domain(P)
     l₊ = length(k₊)
     if l₊ ≥ 1
-        k₊[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+        k₊[1] ∉ I && throw(DomainError(k₊, "input knot vector is out of domain."))
     end
     if l₊ ≥ 2
-        k₊[end] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+        k₊[end] ∉ I && throw(DomainError(k₊, "input knot vector is out of domain."))
     end
     k′ = k + k₊
     P′ = BSplineSpace{p}(k′)

--- a/src/_BSplineSpace.jl
+++ b/src/_BSplineSpace.jl
@@ -469,7 +469,10 @@ function expandspace_I end
 
 function expandspace_I(P::BSplineSpace{p,T}, ::Val{p₊}, k₊::AbstractKnotVector=EmptyKnotVector{T}()) where {p,p₊,T}
     k = knotvector(P)
+    I = domain(P)
     l = length(k)
+    k[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    k[l] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
     k̂ = unique(view(k, 1+p:l-p))
     p′ = p + p₊
     k′ = k + p₊*k̂ + k₊
@@ -479,6 +482,10 @@ end
 
 function expandspace_I(P::BSplineSpace{p,T}, k₊::AbstractKnotVector=EmptyKnotVector{T}()) where {p,T}
     k = knotvector(P)
+    I = domain(P)
+    l = length(k)
+    k[1] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
+    k[l] ∉ I && throw(DomainError(k, "input knot vector is out of domain."))
     k′ = k + k₊
     P′ = BSplineSpace{p}(k′)
     return P′

--- a/test/test_BSplineSpace.jl
+++ b/test/test_BSplineSpace.jl
@@ -169,6 +169,12 @@
         # That was because P1 and P4 is not nondegenerate.
         @test isdegenerate_I(P1)
         @test isdegenerate_I(P4)
+
+        # Additional knot vector should be inside the domain
+        k5 = KnotVector(1:8)
+        P5 = BSplineSpace{3}(k1)
+        @test_throws DomainError expandspace_I(P1, KnotVector([9,19]))
+        @test expandspace_R(P1, KnotVector([9,19])) == expandspace_R(P1, Val(0), KnotVector([9,19]))
     end
 
     @testset "sqsubset and lowered B-spline space" begin

--- a/test/test_BSplineSpace.jl
+++ b/test/test_BSplineSpace.jl
@@ -172,9 +172,9 @@
 
         # Additional knot vector should be inside the domain
         k5 = KnotVector(1:8)
-        P5 = BSplineSpace{3}(k1)
-        @test_throws DomainError expandspace_I(P1, KnotVector([9,19]))
-        @test expandspace_R(P1, KnotVector([9,19])) == expandspace_R(P1, Val(0), KnotVector([9,19]))
+        P5 = BSplineSpace{3}(k5)
+        @test_throws DomainError expandspace_I(P5, KnotVector([9,19]))
+        @test expandspace_R(P5, KnotVector([9,19])) == expandspace_R(P5, Val(0), KnotVector([9,19]))
     end
 
     @testset "sqsubset and lowered B-spline space" begin

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -243,7 +243,7 @@
     @testset "3dim" begin
         a = [Point(i, rand()) for i in 1:n1, j in 1:n2, k in 1:n3]
         p₊ = (Val(1), Val(2), Val(0))
-        k₊ = (KnotVector([4.4,4.7]),KnotVector(Float64[]),KnotVector([42]))
+        k₊ = (KnotVector([4.4,4.7]),KnotVector(Float64[]),KnotVector([1.8]))
 
         @testset "BSplineManifold" begin
             M = BSplineManifold(a, (P1,P2,P3))

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -70,10 +70,9 @@
             @test_throws DomainError refinement_I(M1, (Val(0),), (KnotVector([1.2,5.5,7.2,8.5]),))
             @test_throws DomainError refinement_I(M1, P1′)
             # TODO: fix this with https://github.com/hyrodium/BasicBSpline.jl/issues/358
-            # M1a = refinement(refinement(M1, (Val(1),)), (KnotVector([1.2,5.5,7.2,8.5]),))
-            # M1b = refinement(M1, (Val(1),), (KnotVector([1.2,5.5,7.2,8.5]),))
-            # M1c = refinement(M1, P1′)
-            # @test controlpoints(M1a) ≈ controlpoints(M1b) == controlpoints(M1c)
+            @test_throws DomainError refinement(refinement(M1, (Val(1),)), (KnotVector([1.2,5.5,7.2,8.5]),))
+            @test_throws DomainError refinement(M1, (Val(1),), (KnotVector([1.2,5.5,7.2,8.5]),))
+            M1c = refinement(M1, P1′)
 
             # P2 ⊆ P2′ and P2 ⊑ P2′
             M2a_R = refinement_R(refinement_R(M2, (Val(1),)), (KnotVector([2,2,2,2,2]),))

--- a/test/test_Refinement.jl
+++ b/test/test_Refinement.jl
@@ -69,7 +69,6 @@
             @test_throws DomainError refinement_I(refinement_I(M1, (Val(0),)), (KnotVector([1.2,5.5,7.2,8.5]),))
             @test_throws DomainError refinement_I(M1, (Val(0),), (KnotVector([1.2,5.5,7.2,8.5]),))
             @test_throws DomainError refinement_I(M1, P1′)
-            # TODO: fix this with https://github.com/hyrodium/BasicBSpline.jl/issues/358
             @test_throws DomainError refinement(refinement(M1, (Val(1),)), (KnotVector([1.2,5.5,7.2,8.5]),))
             @test_throws DomainError refinement(M1, (Val(1),), (KnotVector([1.2,5.5,7.2,8.5]),))
             M1c = refinement(M1, P1′)


### PR DESCRIPTION
This PR fixes #358.

**Before this PR**
```julia
julia> using BasicBSpline

julia> p1 = 3
3

julia> k1 = KnotVector(1:8)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8])

julia> P1 = BSplineSpace{p1}(k1)
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8]))

julia> P1′ = expandspace_I(P1, KnotVector([9,19]))
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8, 9, 19]))

julia> domain(P1)
4 .. 5

julia> domain(P1′)
4 .. 7

julia> P1 ⊑ P1′
false
```

**After this PR**
```julia
julia> using BasicBSpline

julia> p1 = 3
3

julia> k1 = KnotVector(1:8)
KnotVector([1, 2, 3, 4, 5, 6, 7, 8])

julia> P1 = BSplineSpace{p1}(k1)
BSplineSpace{3, Int64, KnotVector{Int64}}(KnotVector([1, 2, 3, 4, 5, 6, 7, 8]))

julia> P1′ = expandspace_I(P1, KnotVector([9,19]))
ERROR: DomainError with KnotVector([1, 2, 3, 4, 5, 6, 7, 8]):
input knot vector is out of domain.
```