### PR TITLE
Add `plane` keywork arguments for plotting recipes

### DIFF
--- a/ext/BasicBSplineRecipesBaseExt.jl
+++ b/ext/BasicBSplineRecipesBaseExt.jl
@@ -6,7 +6,7 @@ import BasicBSpline.AbstractFunctionSpace
 using StaticArrays
 
 # B-spline space
-@recipe function f(k::AbstractKnotVector; shift_y=0.02)
+@recipe function f(k::AbstractKnotVector; shift_y=0.02, plane=:xy)
     u = BasicBSpline._vec(k)
     l = length(u)
     v = zeros(Float64, l)
@@ -17,11 +17,20 @@ using StaticArrays
     end
     seriestype := :scatter
     delete!(plotattributes, :shift_y)
-    u, v
+    delete!(plotattributes, :plane)
+    if plane === :xy
+        u, v
+    elseif plane === :xy
+        v, u
+    elseif plane === :xz
+        u, zero(u), v
+    elseif plane === :yz
+        zero(u), u, v
+    end
 end
 
 # B-spline space
-@recipe function f(P::AbstractFunctionSpace; division_number=20)
+@recipe function f(P::AbstractFunctionSpace; division_number=20, plane=:xy)
     k = knotvector(P)
     ts = Float64[]
     for i in 1:length(k)-1
@@ -33,7 +42,16 @@ end
     bs = [bsplinebasis(P,i,t) for t in ts, i in 1:n]
     bb = vec(vcat(bs,zeros(n)'))
     delete!(plotattributes, :division_number)
-    tt, bb
+    delete!(plotattributes, :plane)
+    if plane === :xy
+        tt, bb
+    elseif plane === :xy
+        bb, tt
+    elseif plane === :xz
+        tt, zero(tt), bb
+    elseif plane === :yz
+        zero(tt), tt, bb
+    end
 end
 
 const _Manifold{Dim1, Dim2} = Union{BSplineManifold{Dim1,Deg,<:StaticVector{Dim2,<:Real}}, RationalBSplineManifold{Dim1,Deg,<:StaticVector{Dim2,<:Real}}} where Deg

--- a/ext/BasicBSplineRecipesBaseExt.jl
+++ b/ext/BasicBSplineRecipesBaseExt.jl
@@ -6,17 +6,17 @@ import BasicBSpline.AbstractFunctionSpace
 using StaticArrays
 
 # B-spline space
-@recipe function f(k::AbstractKnotVector; shift_y=0.02, plane=:xy)
+@recipe function f(k::AbstractKnotVector; gap_y=0.02, shift_y=0.0, plane=:xy)
     u = BasicBSpline._vec(k)
     l = length(u)
-    v = zeros(Float64, l)
+    v = fill(float(shift_y), l)
     for i in 2:l
         if u[i-1] == u[i]
-            v[i] = v[i-1] - shift_y
+            v[i] = v[i-1] - gap_y
         end
     end
     seriestype := :scatter
-    delete!(plotattributes, :shift_y)
+    delete!(plotattributes, :gap_y)
     delete!(plotattributes, :plane)
     if plane === :xy
         u, v

--- a/test/test_Plots.jl
+++ b/test/test_Plots.jl
@@ -46,6 +46,32 @@
         @test isfile(path_img)
     end
 
+    @testset "Tensor product of B-spline spaces" begin
+        # Define shape
+        k1 = KnotVector([0.0, 1.5, 2.5, 5.5, 8.0, 9.0, 9.5, 10.0])
+        k2 = knotvector"31 2  121"
+        P1 = BSplineSpace{3}(k1)
+        P2 = BSplineSpace{2}(k2)
+
+        # Choose indices
+        i1 = 3
+        i2 = 4
+
+        # Visualize basis functions
+        xs = range(0,10,length=100)
+        ys = range(1,9,length=100)
+        surface(xs, ys, bsplinebasis.(P1,i1,xs') .* bsplinebasis.(P2,i2,ys))
+        plot!(P1; plane=:xz, label="P1", color=:red)
+        plot!(P2; plane=:yz, label="P2", color=:green)
+        plot!(k1; plane=:xz, label="k1", color=:red, markersize=2)
+        plot!(k2; plane=:yz, label="k2", color=:green, markersize=2)
+
+        path_img = joinpath(dir_out, "bspline_space_tensor_product.png")
+        @test !isfile(path_img)
+        savefig(pl, path_img)
+        @test isfile(path_img)
+    end
+
     @testset "B-spline curve in 2d" begin
         a = [SVector(0, 0), SVector(1, 1), SVector(2, -1), SVector(3, 0), SVector(4, -2), SVector(5, 1)]
         p = 3

--- a/test/test_Plots.jl
+++ b/test/test_Plots.jl
@@ -157,8 +157,9 @@
         pl = plot(M; controlpoints=(;markersize=1))
         path_img = joinpath(dir_out, "bspline_solid_3d.png")
         @test !isfile(path_img)
-        savefig(pl, path_img)
-        @test isfile(path_img)
+        # https://github.com/hyrodium/BasicBSpline.jl/pull/374#issuecomment-1927050884
+        # savefig(pl, path_img)
+        # @test isfile(path_img)
     end
 
     @testset "Rational B-spline curve in 2d" begin
@@ -202,7 +203,8 @@
         pl = plot(M)
         path_img = joinpath(dir_out, "rational_bspline_surface_3d.png")
         @test !isfile(path_img)
-        savefig(pl, path_img)
-        @test isfile(path_img)
+        # https://github.com/hyrodium/BasicBSpline.jl/pull/374#issuecomment-1927050884
+        # savefig(pl, path_img)
+        # @test isfile(path_img)
     end
 end

--- a/test/test_Plots.jl
+++ b/test/test_Plots.jl
@@ -46,8 +46,24 @@
         @test isfile(path_img)
     end
 
+    @testset "B-spline spaces with knotvectors" begin
+        k1 = KnotVector([0.0, 1.5, 2.5, 5.5, 8.0, 9.0, 9.5, 10.0])
+        P1 = BSplineSpace{3}(k1)
+        P2 = expandspace_R(P1, KnotVector([2.0, 3.0, 5.5]))
+
+        pl = plot(P1, label="P1", color=:red)
+        plot!(P2, label="P2", color=:green)
+        plot!(knotvector(P1), label="k1", gap_y=0.01, color=:red)
+        plot!(knotvector(P2); label="k2", gap_y=0.01, shift_y=-0.03, color=:green)
+
+        path_img = joinpath(dir_out, "bspline_spaces_and_their_knotvectors.png")
+        @test !isfile(path_img)
+        savefig(pl, path_img)
+        @test isfile(path_img)
+    end
+
     @testset "Tensor product of B-spline spaces" begin
-        # Define shape
+        # Define piecewise polynomial spaces
         k1 = KnotVector([0.0, 1.5, 2.5, 5.5, 8.0, 9.0, 9.5, 10.0])
         k2 = knotvector"31 2  121"
         P1 = BSplineSpace{3}(k1)
@@ -60,7 +76,7 @@
         # Visualize basis functions
         xs = range(0,10,length=100)
         ys = range(1,9,length=100)
-        surface(xs, ys, bsplinebasis.(P1,i1,xs') .* bsplinebasis.(P2,i2,ys))
+        pl = surface(xs, ys, bsplinebasis.(P1,i1,xs') .* bsplinebasis.(P2,i2,ys))
         plot!(P1; plane=:xz, label="P1", color=:red)
         plot!(P2; plane=:yz, label="P2", color=:green)
         plot!(k1; plane=:xz, label="k1", color=:red, markersize=2)


### PR DESCRIPTION
```julia
using BasicBSpline
using Plots
plotly()

# Define shape
k1 = KnotVector([0.0, 1.5, 2.5, 5.5, 8.0, 9.0, 9.5, 10.0])
k2 = knotvector"31 2  121"
P1 = BSplineSpace{3}(k1)
P2 = BSplineSpace{2}(k2)

# Choose indices
i1 = 3
i2 = 4

# Visualize basis functions
plot(P1; plane=:xz, label="P1", color=:red)
plot!(P2; plane=:yz, label="P2", color=:green)
plot!(k1; plane=:xz, label="k1", color=:red, markersize=2)
plot!(k2; plane=:yz, label="k2", color=:green, markersize=2)
xs = range(0,10,length=100)
ys = range(1,9,length=100)
surface!(xs, ys, bsplinebasis.(P1,i1,xs') .* bsplinebasis.(P2,i2,ys))
```

https://github.com/hyrodium/BasicBSpline.jl/assets/7488140/26605430-2c78-45f6-8bb4-31e0a0f7250a

